### PR TITLE
Refactor user data cleanup and normalize TTS preferences

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@
 # remove them once the seed has run. Auth must be configured for this seed path.
 # See Settings → Admin → Shared providers.
 API_BASE=http://localhost:8880/v1
-API_KEY=api_key_optional
+API_KEY=
 
 # Auth configuration (required in v4+)
 BASE_URL=http://localhost:3003 # Externally facing URL for this app (set to LAN IP for access from other devices on the network)
@@ -88,4 +88,4 @@ S3_BUCKET=
 # (Optional) v4 JSON seed for first-boot runtime config + shared providers.
 # If both are set, RUNTIME_SEED_JSON_PATH is used.
 # RUNTIME_SEED_JSON_PATH=/absolute/path/to/openreader-seed.json
-# RUNTIME_SEED_JSON={"version":1,"runtimeConfig":{"enableUserSignups":true,"restrictUserApiKeys":true,"defaultTtsProvider":"custom-openai","enableTtsProvidersTab":true,"enableAudiobookExport":true,"enableDocxConversion":true,"showAllProviderModels":true,"disableTtsRateLimit":true,"ttsDailyLimitAnonymous":50000,"ttsDailyLimitAuthenticated":500000,"ttsIpDailyLimitAnonymous":100000,"ttsIpDailyLimitAuthenticated":1000000,"ttsCacheMaxSizeBytes":268435456,"ttsCacheTtlMs":1800000,"ttsUpstreamMaxRetries":2,"ttsUpstreamTimeoutMs":285000,"disableComputeRateLimit":true,"computeParseBurstMax":8,"computeParseBurstWindowSec":60,"computeParseSustainedMax":24,"computeParseSustainedWindowSec":600,"maxUploadMb":200,"changelogFeedUrl":"https://docs.openreader.richardr.dev/changelog/manifest.json"},"providers":[{"slug":"default-openai","displayName":"Default (seeded)","providerType":"custom-openai","baseUrl":"http://localhost:8880/v1","apiKey":"api_key_optional","defaultModel":"kokoro","enabled":true}]}
+# RUNTIME_SEED_JSON={"version":1,"runtimeConfig":{"enableUserSignups":true,"restrictUserApiKeys":true,"defaultTtsProvider":"custom-openai","enableTtsProvidersTab":true,"enableAudiobookExport":true,"enableDocxConversion":true,"showAllProviderModels":true,"disableTtsRateLimit":true,"ttsDailyLimitAnonymous":50000,"ttsDailyLimitAuthenticated":500000,"ttsIpDailyLimitAnonymous":100000,"ttsIpDailyLimitAuthenticated":1000000,"ttsCacheMaxSizeBytes":268435456,"ttsCacheTtlMs":1800000,"ttsUpstreamMaxRetries":2,"ttsUpstreamTimeoutMs":285000,"disableComputeRateLimit":true,"computeParseBurstMax":8,"computeParseBurstWindowSec":60,"computeParseSustainedMax":24,"computeParseSustainedWindowSec":600,"maxUploadMb":200,"changelogFeedUrl":"https://docs.openreader.richardr.dev/changelog/manifest.json"},"providers":[{"slug":"default-openai","displayName":"Default (seeded)","providerType":"custom-openai","baseUrl":"http://localhost:8880/v1","defaultModel":"kokoro","enabled":true}]}

--- a/docs-site/docs/configure/admin-panel.md
+++ b/docs-site/docs/configure/admin-panel.md
@@ -50,10 +50,10 @@ Whether users can supply their own personal built-in provider keys is controlled
 
 ### Auto-seeded "default-openai"
 
-On first boot, if `admin_providers` is empty and the legacy `API_KEY` env var is set, OpenReader creates a single shared provider with:
+On first boot, if `admin_providers` is empty and `API_BASE` or `API_KEY` is set, OpenReader creates a single shared provider with:
 
 - slug `default-openai`, displayName `Default (from env)`, providerType `custom-openai`
-- baseUrl from `API_BASE`, apiKey from `API_KEY` (encrypted)
+- baseUrl from `API_BASE`, apiKey from `API_KEY` when provided (blank keys are supported)
 - defaultModel set to `kokoro` (you can edit it in Admin → Shared providers)
 
 After this seed runs, the legacy `API_KEY` / `API_BASE` env vars are no longer read by the TTS routes — the DB row is authoritative. You can rename, edit, disable, or delete this row like any other from the admin UI, and remove the env vars from your `.env` when convenient.
@@ -124,7 +124,7 @@ In v4, runtime site features are managed by admin settings and optional JSON see
 1. Deploy this version with your existing env values in place.
 2. Boot the app once. Open Settings → Admin and verify:
    - Seeded settings appear as **from seed** (if you supplied a runtime JSON seed).
-   - A `default-openai` row exists in **Shared providers** (if you had `API_KEY` set).
+   - A `default-openai` row exists in **Shared providers** (if you had `API_BASE` or `API_KEY` set).
 3. Remove any bootstrap env vars you no longer need from `.env`.
 4. Redeploy. Behavior is unchanged — the DB is now the source of truth.
 

--- a/docs-site/docs/configure/tts-provider-guides/other.md
+++ b/docs-site/docs/configure/tts-provider-guides/other.md
@@ -26,7 +26,7 @@ Known compatible implementations: [Kokoro-FastAPI](./kokoro-fastapi), [KittenTTS
 
 ```env
 API_BASE=http://your-tts-server/v1
-API_KEY=optional-key-if-required
+# API_KEY=optional-key-if-required
 ```
 
 **Or in-app via Settings → TTS Provider:**

--- a/docs-site/docs/deploy/local-development.md
+++ b/docs-site/docs/deploy/local-development.md
@@ -249,7 +249,6 @@ Use one of these `.env` mode templates:
 
 ```env
 API_BASE=http://host.docker.internal:8880/v1
-API_KEY=none
 BASE_URL=http://localhost:3003
 AUTH_SECRET=<generate-with-openssl-rand-hex-32>
 # Optional when you need multiple local origins:
@@ -260,10 +259,9 @@ AUTH_SECRET=<generate-with-openssl-rand-hex-32>
   <TabItem value="auth-with-admin" label="Auth + Admin Panel">
 
 ```env
-# API_BASE / API_KEY are seeded into the admin "default-openai" shared provider
+# API_BASE and optional API_KEY are seeded into the admin "default-openai" shared provider
 # on first boot, then no longer read. Manage them in Settings → Admin afterwards.
 API_BASE=http://host.docker.internal:8880/v1
-API_KEY=none
 BASE_URL=http://localhost:3003
 AUTH_SECRET=<generate-with-openssl-rand-hex-32>
 # Comma-separated emails to auto-promote to admin on signin.
@@ -275,7 +273,6 @@ ADMIN_EMAILS=you@example.com
 
 ```env
 API_BASE=http://host.docker.internal:8880/v1
-API_KEY=none
 USE_EMBEDDED_WEED_MINI=false
 BASE_URL=http://localhost:3003
 AUTH_SECRET=<generate-with-openssl-rand-hex-32>
@@ -293,7 +290,6 @@ S3_SECRET_ACCESS_KEY=your-secret-key
 
 ```env
 API_BASE=http://host.docker.internal:8880/v1
-API_KEY=none
 BASE_URL=http://localhost:3003
 AUTH_SECRET=<generate-with-openssl-rand-hex-32>
 COMPUTE_WORKER_URL=http://localhost:8081

--- a/docs-site/docs/docker-quick-start.md
+++ b/docs-site/docs/docker-quick-start.md
@@ -42,7 +42,6 @@ docker run --name openreader \
   -p 8333:8333 \
   -v openreader_docstore:/app/docstore \
   -e API_BASE=http://host.docker.internal:8880/v1 \
-  -e API_KEY=none \
   -e BASE_URL=http://localhost:3003 \
   -e AUTH_SECRET=$(openssl rand -hex 32) \
   -e ADMIN_EMAILS=you@example.com \
@@ -54,7 +53,7 @@ What this command enables:
 - `-p 3003:3003`: exposes the OpenReader web app/API.
 - `-p 8333:8333`: exposes embedded SeaweedFS S3 endpoint for direct browser presigned upload/download.
 - `-v openreader_docstore:/app/docstore`: persists SQLite metadata, SeaweedFS blob data, and migration/runtime state.
-- `-e API_BASE=...` / `-e API_KEY=...`: **first-boot seed only.** On the first container start, these are auto-migrated into a `default-openai` admin shared provider stored in the DB (key encrypted at rest). After that, the running app no longer reads them — manage the provider from **Settings → Admin → Shared providers**. See [Admin Panel](./configure/admin-panel).
+- `-e API_BASE=...` / optional `-e API_KEY=...`: **first-boot seed only.** On the first container start, these are auto-migrated into a `default-openai` admin shared provider stored in the DB (key encrypted at rest when provided). After that, the running app no longer reads them — manage the provider from **Settings → Admin → Shared providers**. See [Admin Panel](./configure/admin-panel).
 - `-e BASE_URL=...` and `-e AUTH_SECRET=...`: required for v4+ auth/session startup.
 - `-e ADMIN_EMAILS=...`: (optional, requires auth) comma-separated emails auto-promoted to admin. Admins see the **Admin** tab in Settings.
 
@@ -70,7 +69,6 @@ docker run --name openreader \
   -p 8333:8333 \
   -v openreader_docstore:/app/docstore \
   -e API_BASE=http://host.docker.internal:8880/v1 \
-  -e API_KEY=none \
   -e BASE_URL=http://<YOUR_LAN_IP>:3003 \
   -e AUTH_SECRET=$(openssl rand -hex 32) \
   -e AUTH_TRUSTED_ORIGINS=http://localhost:3003,http://127.0.0.1:3003 \
@@ -88,7 +86,7 @@ What this command enables:
 - `AUTH_TRUSTED_ORIGINS` allows localhost loopback origins in addition to your primary LAN origin.
 - `USE_ANONYMOUS_AUTH_SESSIONS=true` allows guest sessions while auth is enabled.
 - `API_BASE` seeds the default TTS endpoint into the admin-managed `default-openai` shared provider on first boot. Edit it from **Settings → Admin → Shared providers** after that.
-- `API_KEY` seeds the default provider's key (encrypted at rest). After first boot, manage keys from the admin panel or set per-user keys if `restrictUserApiKeys=false`. Always needed for seeding the default provider.
+- `API_KEY` optionally seeds the default provider's key (encrypted at rest). Omit it for an upstream that does not require authentication.
 - `ADMIN_EMAILS=...` (optional) auto-promotes the listed email(s) to admin so they can manage shared providers and site feature flags from the UI.
 - `openreader_docstore` volume keeps data persistent across restarts.
 
@@ -112,7 +110,7 @@ What this command enables:
 - Fast startup with only the required auth env vars.
 - No persistent volume (`/app/docstore` stays container-local), so data is ephemeral unless you add a mount.
 - The app still requires `BASE_URL` + `AUTH_SECRET` in v4+, so include them even in minimal mode.
-- No TTS provider preset by default. Configure `API_BASE`/`API_KEY` on first boot if you want a seeded shared provider, or run auth+admin mode and manage providers from the admin panel.
+- No TTS provider preset by default. Configure `API_BASE` and, when required, `API_KEY` on first boot if you want a seeded shared provider, or run auth+admin mode and manage providers from the admin panel.
 
 </TabItem>
 </Tabs>

--- a/docs-site/docs/reference/environment-variables.md
+++ b/docs-site/docs/reference/environment-variables.md
@@ -96,27 +96,6 @@ Optional first-boot bootstrap API key for the auto-created `default-openai` shar
 - Stored encrypted at rest after bootstrap.
 - After bootstrap, provider configuration is DB-backed and managed in **Settings → Admin → Shared providers**.
 
-### TTS Daily Rate Limiting (Runtime Settings)
-
-Managed as runtime config in **Settings → Admin → Site features**.
-
-- `disableTtsRateLimit` default: `true` (daily TTS limits disabled)
-- `ttsDailyLimitAnonymous` default: `50000`
-- `ttsDailyLimitAuthenticated` default: `500000`
-- `ttsIpDailyLimitAnonymous` default: `100000`
-- `ttsIpDailyLimitAuthenticated` default: `1000000`
-
-### TTS Upstream Settings (Runtime Settings)
-
-Managed as runtime config in **Settings → Admin → Site features → TTS upstream**.
-
-- `ttsUpstreamMaxRetries` default: `2`
-- `ttsUpstreamTimeoutMs` default: `285000`
-- `ttsCacheMaxSizeBytes` default: `268435456` (256 MB)
-- `ttsCacheTtlMs` default: `1800000` (30 minutes)
-
-There are no dedicated env vars for these runtime settings.
-
 ## Auth and Identity
 
 ### BASE_URL
@@ -338,19 +317,6 @@ External compute worker URL.
 ### COMPUTE_WORKER_TOKEN
 
 Shared token for app-to-external-worker requests.
-
-## Compute PDF Parsing Rate Limiting (Runtime Settings)
-
-Managed as runtime config in **Settings → Admin → Site features**.
-
-- `disableComputeRateLimit` default: `true`
-- `computeParseBurstMax` default: `8`
-- `computeParseBurstWindowSec` default: `60`
-- `computeParseSustainedMax` default: `24`
-- `computeParseSustainedWindowSec` default: `600`
-- `maxUploadMb` default: `200`
-
-There are no dedicated env vars for these runtime settings.
 
 ## Audio Runtime
 

--- a/docs-site/docs/reference/environment-variables.md
+++ b/docs-site/docs/reference/environment-variables.md
@@ -85,7 +85,7 @@ App server log level.
 Optional first-boot bootstrap base URL for the auto-created `default-openai` shared provider.
 
 - Example: `http://host.docker.internal:8880/v1`
-- Read only for provider bootstrap when shared providers are empty and `API_KEY` is set.
+- Read only for provider bootstrap when shared providers are empty. Setting `API_BASE` is sufficient; `API_KEY` may be blank.
 - After bootstrap, provider configuration is DB-backed and managed in **Settings → Admin → Shared providers**.
 
 ### API_KEY
@@ -446,7 +446,6 @@ Example:
       "displayName": "Default (seeded)",
       "providerType": "custom-openai",
       "baseUrl": "http://localhost:8880/v1",
-      "apiKey": "api_key_optional",
       "defaultModel": "kokoro",
       "enabled": true
     }
@@ -457,7 +456,7 @@ Example:
 Provider fallback behavior:
 
 - If the JSON seed includes `providers` (including an empty array), `API_BASE` / `API_KEY` fallback is skipped.
-- If the JSON seed does not include a `providers` key, the legacy `API_BASE` / `API_KEY` bootstrap fallback can still create `default-openai` when provider rows are empty.
+- If the JSON seed does not include a `providers` key, the legacy `API_BASE` / `API_KEY` bootstrap fallback can still create `default-openai` when provider rows are empty. `API_BASE` alone is sufficient for an upstream that does not require authentication.
 
 Precedence summary:
 

--- a/drizzle/postgres/0010_user-data-cleanup-cascades.sql
+++ b/drizzle/postgres/0010_user-data-cleanup-cascades.sql
@@ -1,0 +1,8 @@
+DELETE FROM "user_job_events" WHERE NOT EXISTS (
+	SELECT 1 FROM "user" WHERE "user"."id" = "user_job_events"."user_id"
+);--> statement-breakpoint
+DELETE FROM "user_tts_chars" WHERE NOT EXISTS (
+	SELECT 1 FROM "user" WHERE "user"."id" = "user_tts_chars"."user_id"
+);--> statement-breakpoint
+ALTER TABLE "user_job_events" ADD CONSTRAINT "user_job_events_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_tts_chars" ADD CONSTRAINT "user_tts_chars_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/postgres/meta/0010_snapshot.json
+++ b/drizzle/postgres/meta/0010_snapshot.json
@@ -1,0 +1,1922 @@
+{
+  "id": "7aaaea38-619e-42d8-b683-6231e6221d33",
+  "prevId": "23b90a4b-fb63-4f9a-9230-09ca218d0b78",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_providers": {
+      "name": "admin_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_last4": {
+          "name": "api_key_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_instructions": {
+          "name": "default_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "admin_providers_slug_unique": {
+          "name": "admin_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_settings": {
+      "name": "admin_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'admin'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audiobook_chapters": {
+      "name": "audiobook_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chapter_index": {
+          "name": "chapter_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audiobook_chapters_user_id_user_id_fk": {
+          "name": "audiobook_chapters_user_id_user_id_fk",
+          "tableFrom": "audiobook_chapters",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audiobook_chapters_book_id_user_id_audiobooks_id_user_id_fk": {
+          "name": "audiobook_chapters_book_id_user_id_audiobooks_id_user_id_fk",
+          "tableFrom": "audiobook_chapters",
+          "tableTo": "audiobooks",
+          "columnsFrom": [
+            "book_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audiobook_chapters_id_user_id_pk": {
+          "name": "audiobook_chapters_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audiobooks": {
+      "name": "audiobooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_path": {
+          "name": "cover_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audiobooks_user_id_user_id_fk": {
+          "name": "audiobooks_user_id_user_id_fk",
+          "tableFrom": "audiobooks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audiobooks_id_user_id_pk": {
+          "name": "audiobooks_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_previews": {
+      "name": "document_previews",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "source_last_modified_ms": {
+          "name": "source_last_modified_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'image/jpeg'"
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until_ms": {
+          "name": "lease_until_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at_ms": {
+          "name": "updated_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_document_previews_status_lease": {
+          "name": "idx_document_previews_status_lease",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_until_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_previews_document_id_namespace_variant_pk": {
+          "name": "document_previews_document_id_namespace_variant_pk",
+          "columns": [
+            "document_id",
+            "namespace",
+            "variant"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.document_settings": {
+      "name": "document_settings",
+      "schema": "",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_json": {
+          "name": "data_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "client_updated_at_ms": {
+          "name": "client_updated_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {
+        "idx_document_settings_user_id": {
+          "name": "idx_document_settings_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_settings_user_id_user_id_fk": {
+          "name": "document_settings_user_id_user_id_fk",
+          "tableFrom": "document_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_settings_document_id_user_id_pk": {
+          "name": "document_settings_document_id_user_id_pk",
+          "columns": [
+            "document_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {
+        "idx_documents_user_id": {
+          "name": "idx_documents_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_documents_user_id_last_modified": {
+          "name": "idx_documents_user_id_last_modified",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_modified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_user_id_user_id_fk": {
+          "name": "documents_user_id_user_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "documents_id_user_id_pk": {
+          "name": "documents_id_user_id_pk",
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tts_segment_entries": {
+      "name": "tts_segment_entries",
+      "schema": "",
+      "columns": {
+        "segment_entry_id": {
+          "name": "segment_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reader_type": {
+          "name": "reader_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_version": {
+          "name": "document_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_index": {
+          "name": "segment_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_key": {
+          "name": "segment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locator_reader_rank": {
+          "name": "locator_reader_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator_reader_type": {
+          "name": "locator_reader_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator_page": {
+          "name": "locator_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator_spine_index": {
+          "name": "locator_spine_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator_spine_href": {
+          "name": "locator_spine_href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator_char_offset": {
+          "name": "locator_char_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator_location": {
+          "name": "locator_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locator_identity_key": {
+          "name": "locator_identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_length": {
+          "name": "text_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {
+        "idx_tts_segment_entries_manifest_sort": {
+          "name": "idx_tts_segment_entries_manifest_sort",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator_reader_rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator_spine_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator_char_offset",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator_spine_href",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator_page",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator_location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator_identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tts_segment_entries_manifest_group": {
+          "name": "idx_tts_segment_entries_manifest_group",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locator_identity_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tts_segment_entries_scope": {
+          "name": "idx_tts_segment_entries_scope",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "document_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tts_segment_entries_user_id_user_id_fk": {
+          "name": "tts_segment_entries_user_id_user_id_fk",
+          "tableFrom": "tts_segment_entries",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tts_segment_entries_segment_entry_id_user_id_pk": {
+          "name": "tts_segment_entries_segment_entry_id_user_id_pk",
+          "columns": [
+            "segment_entry_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tts_segment_variants": {
+      "name": "tts_segment_variants",
+      "schema": "",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_entry_id": {
+          "name": "segment_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_hash": {
+          "name": "settings_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings_json": {
+          "name": "settings_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_key": {
+          "name": "audio_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audio_format": {
+          "name": "audio_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mp3'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alignment_json": {
+          "name": "alignment_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {
+        "idx_tts_segment_variants_entry": {
+          "name": "idx_tts_segment_variants_entry",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tts_segment_variants_status": {
+          "name": "idx_tts_segment_variants_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tts_segment_variants_unique_settings": {
+          "name": "idx_tts_segment_variants_unique_settings",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "segment_entry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "settings_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tts_segment_variants_user_id_user_id_fk": {
+          "name": "tts_segment_variants_user_id_user_id_fk",
+          "tableFrom": "tts_segment_variants",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tts_segment_variants_segment_entry_id_user_id_tts_segment_entries_segment_entry_id_user_id_fk": {
+          "name": "tts_segment_variants_segment_entry_id_user_id_tts_segment_entries_segment_entry_id_user_id_fk",
+          "tableFrom": "tts_segment_variants",
+          "tableTo": "tts_segment_entries",
+          "columnsFrom": [
+            "segment_entry_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "segment_entry_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tts_segment_variants_segment_id_user_id_pk": {
+          "name": "tts_segment_variants_segment_id_user_id_pk",
+          "columns": [
+            "segment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_document_progress": {
+      "name": "user_document_progress",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reader_type": {
+          "name": "reader_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_updated_at_ms": {
+          "name": "client_updated_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {
+        "idx_user_document_progress_user_id_updated_at": {
+          "name": "idx_user_document_progress_user_id_updated_at",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_document_progress_user_id_user_id_fk": {
+          "name": "user_document_progress_user_id_user_id_fk",
+          "tableFrom": "user_document_progress",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_document_progress_user_id_document_id_pk": {
+          "name": "user_document_progress_user_id_document_id_pk",
+          "columns": [
+            "user_id",
+            "document_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_job_events": {
+      "name": "user_job_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "op_id": {
+          "name": "op_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {
+        "idx_user_job_events_user_action_created": {
+          "name": "idx_user_job_events_user_action_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_job_events_user_id_user_id_fk": {
+          "name": "user_job_events_user_id_user_id_fk",
+          "tableFrom": "user_job_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_job_events_user_id_action_op_id_pk": {
+          "name": "user_job_events_user_id_action_op_id_pk",
+          "columns": [
+            "user_id",
+            "action",
+            "op_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data_json": {
+          "name": "data_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "client_updated_at_ms": {
+          "name": "client_updated_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tts_chars": {
+      "name": "user_tts_chars",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "(extract(epoch from now()) * 1000)::bigint"
+        }
+      },
+      "indexes": {
+        "idx_user_tts_chars_date": {
+          "name": "idx_user_tts_chars_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_tts_chars_user_id_user_id_fk": {
+          "name": "user_tts_chars_user_id_user_id_fk",
+          "tableFrom": "user_tts_chars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tts_chars_user_id_date_pk": {
+          "name": "user_tts_chars_user_id_date_pk",
+          "columns": [
+            "user_id",
+            "date"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/postgres/meta/_journal.json
+++ b/drizzle/postgres/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1780625663880,
       "tag": "0009_drop_pdf_parse",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1780785284335,
+      "tag": "0010_user-data-cleanup-cascades",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/sqlite/0010_user-data-cleanup-cascades.sql
+++ b/drizzle/sqlite/0010_user-data-cleanup-cascades.sql
@@ -1,0 +1,35 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+DELETE FROM `user_job_events` WHERE NOT EXISTS (
+	SELECT 1 FROM `user` WHERE `user`.`id` = `user_job_events`.`user_id`
+);--> statement-breakpoint
+DELETE FROM `user_tts_chars` WHERE NOT EXISTS (
+	SELECT 1 FROM `user` WHERE `user`.`id` = `user_tts_chars`.`user_id`
+);--> statement-breakpoint
+CREATE TABLE `__new_user_job_events` (
+	`user_id` text NOT NULL,
+	`action` text NOT NULL,
+	`op_id` text NOT NULL,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+	PRIMARY KEY(`user_id`, `action`, `op_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_user_job_events`("user_id", "action", "op_id", "created_at") SELECT "user_id", "action", "op_id", "created_at" FROM `user_job_events`;--> statement-breakpoint
+DROP TABLE `user_job_events`;--> statement-breakpoint
+ALTER TABLE `__new_user_job_events` RENAME TO `user_job_events`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `idx_user_job_events_user_action_created` ON `user_job_events` (`user_id`,`action`,`created_at`);--> statement-breakpoint
+CREATE TABLE `__new_user_tts_chars` (
+	`user_id` text NOT NULL,
+	`date` text NOT NULL,
+	`char_count` integer DEFAULT 0,
+	`created_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+	`updated_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)),
+	PRIMARY KEY(`user_id`, `date`),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_user_tts_chars`("user_id", "date", "char_count", "created_at", "updated_at") SELECT "user_id", "date", "char_count", "created_at", "updated_at" FROM `user_tts_chars`;--> statement-breakpoint
+DROP TABLE `user_tts_chars`;--> statement-breakpoint
+ALTER TABLE `__new_user_tts_chars` RENAME TO `user_tts_chars`;--> statement-breakpoint
+CREATE INDEX `idx_user_tts_chars_date` ON `user_tts_chars` (`date`);

--- a/drizzle/sqlite/meta/0010_snapshot.json
+++ b/drizzle/sqlite/meta/0010_snapshot.json
@@ -1,0 +1,1765 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6f0bbd3d-f8aa-49d1-8565-853f2b2654cb",
+  "prevId": "2c23f770-269c-4cae-a71e-4ef88355681f",
+  "tables": {
+    "admin_providers": {
+      "name": "admin_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_ciphertext": {
+          "name": "api_key_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_iv": {
+          "name": "api_key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_last4": {
+          "name": "api_key_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_instructions": {
+          "name": "default_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "admin_providers_slug_unique": {
+          "name": "admin_providers_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "admin_settings": {
+      "name": "admin_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_json": {
+          "name": "value_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'admin'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audiobook_chapters": {
+      "name": "audiobook_chapters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chapter_index": {
+          "name": "chapter_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audiobook_chapters_user_id_user_id_fk": {
+          "name": "audiobook_chapters_user_id_user_id_fk",
+          "tableFrom": "audiobook_chapters",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audiobook_chapters_book_id_user_id_audiobooks_id_user_id_fk": {
+          "name": "audiobook_chapters_book_id_user_id_audiobooks_id_user_id_fk",
+          "tableFrom": "audiobook_chapters",
+          "tableTo": "audiobooks",
+          "columnsFrom": [
+            "book_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audiobook_chapters_id_user_id_pk": {
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "name": "audiobook_chapters_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audiobooks": {
+      "name": "audiobooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_path": {
+          "name": "cover_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audiobooks_user_id_user_id_fk": {
+          "name": "audiobooks_user_id_user_id_fk",
+          "tableFrom": "audiobooks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "audiobooks_id_user_id_pk": {
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "name": "audiobooks_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_previews": {
+      "name": "document_previews",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "source_last_modified_ms": {
+          "name": "source_last_modified_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'image/jpeg'"
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lease_until_ms": {
+          "name": "lease_until_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at_ms": {
+          "name": "created_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at_ms": {
+          "name": "updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_document_previews_status_lease": {
+          "name": "idx_document_previews_status_lease",
+          "columns": [
+            "status",
+            "lease_until_ms"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "document_previews_document_id_namespace_variant_pk": {
+          "columns": [
+            "document_id",
+            "namespace",
+            "variant"
+          ],
+          "name": "document_previews_document_id_namespace_variant_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "document_settings": {
+      "name": "document_settings",
+      "columns": {
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_json": {
+          "name": "data_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "client_updated_at_ms": {
+          "name": "client_updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_document_settings_user_id": {
+          "name": "idx_document_settings_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "document_settings_user_id_user_id_fk": {
+          "name": "document_settings_user_id_user_id_fk",
+          "tableFrom": "document_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "document_settings_document_id_user_id_pk": {
+          "columns": [
+            "document_id",
+            "user_id"
+          ],
+          "name": "document_settings_document_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_documents_user_id": {
+          "name": "idx_documents_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_documents_user_id_last_modified": {
+          "name": "idx_documents_user_id_last_modified",
+          "columns": [
+            "user_id",
+            "last_modified"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "documents_user_id_user_id_fk": {
+          "name": "documents_user_id_user_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "documents_id_user_id_pk": {
+          "columns": [
+            "id",
+            "user_id"
+          ],
+          "name": "documents_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tts_segment_entries": {
+      "name": "tts_segment_entries",
+      "columns": {
+        "segment_entry_id": {
+          "name": "segment_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reader_type": {
+          "name": "reader_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_version": {
+          "name": "document_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "segment_index": {
+          "name": "segment_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "segment_key": {
+          "name": "segment_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locator_reader_rank": {
+          "name": "locator_reader_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator_reader_type": {
+          "name": "locator_reader_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator_page": {
+          "name": "locator_page",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator_spine_index": {
+          "name": "locator_spine_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator_spine_href": {
+          "name": "locator_spine_href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator_char_offset": {
+          "name": "locator_char_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator_location": {
+          "name": "locator_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locator_identity_key": {
+          "name": "locator_identity_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_hash": {
+          "name": "text_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_length": {
+          "name": "text_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_tts_segment_entries_manifest_sort": {
+          "name": "idx_tts_segment_entries_manifest_sort",
+          "columns": [
+            "user_id",
+            "document_id",
+            "document_version",
+            "locator_reader_rank",
+            "locator_spine_index",
+            "locator_char_offset",
+            "locator_spine_href",
+            "locator_page",
+            "locator_location",
+            "segment_index",
+            "locator_identity_key"
+          ],
+          "isUnique": false
+        },
+        "idx_tts_segment_entries_manifest_group": {
+          "name": "idx_tts_segment_entries_manifest_group",
+          "columns": [
+            "user_id",
+            "document_id",
+            "document_version",
+            "segment_index",
+            "locator_identity_key"
+          ],
+          "isUnique": false
+        },
+        "idx_tts_segment_entries_scope": {
+          "name": "idx_tts_segment_entries_scope",
+          "columns": [
+            "user_id",
+            "document_id",
+            "document_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tts_segment_entries_user_id_user_id_fk": {
+          "name": "tts_segment_entries_user_id_user_id_fk",
+          "tableFrom": "tts_segment_entries",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tts_segment_entries_segment_entry_id_user_id_pk": {
+          "columns": [
+            "segment_entry_id",
+            "user_id"
+          ],
+          "name": "tts_segment_entries_segment_entry_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tts_segment_variants": {
+      "name": "tts_segment_variants",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "segment_entry_id": {
+          "name": "segment_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings_hash": {
+          "name": "settings_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings_json": {
+          "name": "settings_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audio_key": {
+          "name": "audio_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_format": {
+          "name": "audio_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'mp3'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alignment_json": {
+          "name": "alignment_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_tts_segment_variants_entry": {
+          "name": "idx_tts_segment_variants_entry",
+          "columns": [
+            "user_id",
+            "segment_entry_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_tts_segment_variants_status": {
+          "name": "idx_tts_segment_variants_status",
+          "columns": [
+            "user_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_tts_segment_variants_unique_settings": {
+          "name": "idx_tts_segment_variants_unique_settings",
+          "columns": [
+            "user_id",
+            "segment_entry_id",
+            "settings_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tts_segment_variants_user_id_user_id_fk": {
+          "name": "tts_segment_variants_user_id_user_id_fk",
+          "tableFrom": "tts_segment_variants",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tts_segment_variants_segment_entry_id_user_id_tts_segment_entries_segment_entry_id_user_id_fk": {
+          "name": "tts_segment_variants_segment_entry_id_user_id_tts_segment_entries_segment_entry_id_user_id_fk",
+          "tableFrom": "tts_segment_variants",
+          "tableTo": "tts_segment_entries",
+          "columnsFrom": [
+            "segment_entry_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "segment_entry_id",
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tts_segment_variants_segment_id_user_id_pk": {
+          "columns": [
+            "segment_id",
+            "user_id"
+          ],
+          "name": "tts_segment_variants_segment_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_document_progress": {
+      "name": "user_document_progress",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reader_type": {
+          "name": "reader_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_updated_at_ms": {
+          "name": "client_updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_user_document_progress_user_id_updated_at": {
+          "name": "idx_user_document_progress_user_id_updated_at",
+          "columns": [
+            "user_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_document_progress_user_id_user_id_fk": {
+          "name": "user_document_progress_user_id_user_id_fk",
+          "tableFrom": "user_document_progress",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_document_progress_user_id_document_id_pk": {
+          "columns": [
+            "user_id",
+            "document_id"
+          ],
+          "name": "user_document_progress_user_id_document_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_job_events": {
+      "name": "user_job_events",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "op_id": {
+          "name": "op_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_user_job_events_user_action_created": {
+          "name": "idx_user_job_events_user_action_created",
+          "columns": [
+            "user_id",
+            "action",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_job_events_user_id_user_id_fk": {
+          "name": "user_job_events_user_id_user_id_fk",
+          "tableFrom": "user_job_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_job_events_user_id_action_op_id_pk": {
+          "columns": [
+            "user_id",
+            "action",
+            "op_id"
+          ],
+          "name": "user_job_events_user_id_action_op_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_preferences": {
+      "name": "user_preferences",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_json": {
+          "name": "data_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "client_updated_at_ms": {
+          "name": "client_updated_at_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_tts_chars": {
+      "name": "user_tts_chars",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_user_tts_chars_date": {
+          "name": "idx_user_tts_chars_date",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_tts_chars_user_id_user_id_fk": {
+          "name": "user_tts_chars_user_id_user_id_fk",
+          "tableFrom": "user_tts_chars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tts_chars_user_id_date_pk": {
+          "columns": [
+            "user_id",
+            "date"
+          ],
+          "name": "user_tts_chars_user_id_date_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/sqlite/meta/_journal.json
+++ b/drizzle/sqlite/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1780625663601,
       "tag": "0009_drop_pdf_parse",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1780785284041,
+      "tag": "0010_user-data-cleanup-cascades",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/app/layout.tsx
+++ b/src/app/(app)/app/layout.tsx
@@ -2,16 +2,15 @@
 
 import type { ReactNode } from 'react';
 
-import { ConfigProvider } from '@/contexts/ConfigContext';
 import { DocumentProvider } from '@/contexts/DocumentContext';
 import { OnboardingFlowProvider } from '@/contexts/OnboardingFlowContext';
 
+// ConfigProvider is mounted once in the shared (app) layout so it survives
+// library <-> reader navigation; do not re-wrap it here.
 export default function AppHomeLayout({ children }: { children: ReactNode }) {
   return (
-    <ConfigProvider>
-      <DocumentProvider>
-        <OnboardingFlowProvider>{children}</OnboardingFlowProvider>
-      </DocumentProvider>
-    </ConfigProvider>
+    <DocumentProvider>
+      <OnboardingFlowProvider>{children}</OnboardingFlowProvider>
+    </DocumentProvider>
   );
 }

--- a/src/app/(app)/epub/[id]/layout.tsx
+++ b/src/app/(app)/epub/[id]/layout.tsx
@@ -2,15 +2,14 @@
 
 import type { ReactNode } from 'react';
 
-import { ConfigProvider } from '@/contexts/ConfigContext';
 import { TTSProvider } from '@/contexts/TTSContext';
 
+// ConfigProvider is mounted once in the shared (app) layout so it survives
+// library <-> reader navigation; do not re-wrap it here.
 export default function EpubReaderLayout({ children }: { children: ReactNode }) {
   return (
-    <ConfigProvider>
-      <TTSProvider>
-        {children}
-      </TTSProvider>
-    </ConfigProvider>
+    <TTSProvider>
+      {children}
+    </TTSProvider>
   );
 }

--- a/src/app/(app)/html/[id]/layout.tsx
+++ b/src/app/(app)/html/[id]/layout.tsx
@@ -2,13 +2,12 @@
 
 import type { ReactNode } from 'react';
 
-import { ConfigProvider } from '@/contexts/ConfigContext';
 import { TTSProvider } from '@/contexts/TTSContext';
 
+// ConfigProvider is mounted once in the shared (app) layout so it survives
+// library <-> reader navigation; do not re-wrap it here.
 export default function HtmlReaderLayout({ children }: { children: ReactNode }) {
   return (
-    <ConfigProvider>
-      <TTSProvider>{children}</TTSProvider>
-    </ConfigProvider>
+    <TTSProvider>{children}</TTSProvider>
   );
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { Toaster } from 'react-hot-toast';
 
 import { Providers } from '@/app/providers';
+import { ConfigProvider } from '@/contexts/ConfigContext';
 import { AppMain, AppShell } from '@/components/layout';
 import { getAuthBaseUrl, isAnonymousAuthSessionsEnabled, isGithubAuthEnabled } from '@/lib/server/auth/config';
 
@@ -33,9 +34,17 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       allowAnonymousAuthSessions={allowAnonymousAuthSessions}
       githubAuthEnabled={githubAuthEnabled}
     >
-      <AppShell>
-        <AppMain>{children}</AppMain>
-      </AppShell>
+      {/* ConfigProvider lives here, in the shared (app) layout, so it stays
+          mounted across library <-> reader navigation. Mounting it per-route
+          re-ran the Dexie/server hydration race on every navigation, causing
+          the reader to briefly use the admin-default provider until a full
+          page refresh. A single shared instance keeps the user's saved
+          provider hydrated the whole time. */}
+      <ConfigProvider>
+        <AppShell>
+          <AppMain>{children}</AppMain>
+        </AppShell>
+      </ConfigProvider>
       <Toaster
         toastOptions={{
           style: {

--- a/src/app/(app)/pdf/[id]/layout.tsx
+++ b/src/app/(app)/pdf/[id]/layout.tsx
@@ -2,13 +2,12 @@
 
 import type { ReactNode } from 'react';
 
-import { ConfigProvider } from '@/contexts/ConfigContext';
 import { TTSProvider } from '@/contexts/TTSContext';
 
+// ConfigProvider is mounted once in the shared (app) layout so it survives
+// library <-> reader navigation; do not re-wrap it here.
 export default function PdfReaderLayout({ children }: { children: ReactNode }) {
   return (
-    <ConfigProvider>
-      <TTSProvider>{children}</TTSProvider>
-    </ConfigProvider>
+    <TTSProvider>{children}</TTSProvider>
   );
 }

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/lib/server/auth/auth';
 import { getOpenReaderTestNamespace } from '@/lib/server/testing/test-namespace';
 import { deleteUserStorageData } from '@/lib/server/user/data-cleanup';
-import { errorToLog, hashForLog, serverLogger } from '@/lib/server/logger';
+import { errorToLog, serverLogger } from '@/lib/server/logger';
 import { errorResponse } from '@/lib/server/errors/next-response';
 
 export async function DELETE() {
@@ -18,21 +18,12 @@ export async function DELETE() {
   }
 
   try {
-    // Best-effort cleanup for test namespaced storage using request context.
-    // The Better Auth beforeDelete hook still runs and handles non-namespaced data.
+    // Clean test-namespaced storage using request context. The Better Auth
+    // beforeDelete hook handles non-namespaced storage and blocks deletion if
+    // either cleanup cannot complete.
     const testNamespace = getOpenReaderTestNamespace(reqHeaders);
     if (testNamespace) {
-      try {
-        await deleteUserStorageData(session.user.id, testNamespace);
-      } catch (error) {
-        serverLogger.warn({
-          event: 'account.delete.storage_cleanup_failed',
-          degraded: true,
-          step: 'namespaced_storage_cleanup',
-          userIdHash: hashForLog(session.user.id),
-          error: errorToLog(error),
-        }, 'Failed to clean up namespaced user storage before deletion');
-      }
+      await deleteUserStorageData(session.user.id, testNamespace);
     }
 
     // Use Better Auth's built-in deleteUser to handle cascading cleanup

--- a/src/app/api/audiobook/chapter/route.ts
+++ b/src/app/api/audiobook/chapter/route.ts
@@ -501,7 +501,7 @@ export async function POST(request: NextRequest) {
         normalize: { code: 'AUDIOBOOK_CHAPTER_UNSUPPORTED_PROVIDER', errorClass: 'validation', httpStatus: 500 },
       });
     }
-    const openApiKey = credResolved.apiKey || 'none';
+    const openApiKey = credResolved.apiKey;
     const openApiBaseUrl = credResolved.baseUrl;
     const effectiveProviderRef = credResolved.adminRecord?.slug || requestedProvider;
     const model = resolveTtsModelForProvider({

--- a/src/app/api/documents/blob/get/fallback/route.ts
+++ b/src/app/api/documents/blob/get/fallback/route.ts
@@ -9,6 +9,7 @@ import { getOpenReaderTestNamespace } from '@/lib/server/testing/test-namespace'
 import { isS3Configured } from '@/lib/server/storage/s3';
 import { errorToLog, serverLogger } from '@/lib/server/logger';
 import { errorResponse } from '@/lib/server/errors/next-response';
+import { deleteDocumentTtsSegmentCache } from '@/lib/server/tts/segments-cache';
 
 export const dynamic = 'force-dynamic';
 
@@ -80,9 +81,14 @@ export async function GET(req: NextRequest) {
       });
     } catch (error) {
       if (isMissingBlobError(error)) {
+        await deleteDocumentTtsSegmentCache({
+          userId: doc.userId,
+          documentId: id,
+          namespace: testNamespace,
+        });
         await db
           .delete(documents)
-          .where(and(eq(documents.id, id), inArray(documents.userId, allowedUserIds)));
+          .where(and(eq(documents.id, id), eq(documents.userId, doc.userId)));
         return NextResponse.json({ error: 'Not found' }, { status: 404 });
       }
       throw error;

--- a/src/app/api/documents/blob/preview/fallback/route.ts
+++ b/src/app/api/documents/blob/preview/fallback/route.ts
@@ -22,6 +22,7 @@ import {
 import { extractRawTextSnippet } from '@/lib/server/documents/text-snippets';
 import { getOpenReaderTestNamespace } from '@/lib/server/testing/test-namespace';
 import { isS3Configured } from '@/lib/server/storage/s3';
+import { deleteDocumentTtsSegmentCache } from '@/lib/server/tts/segments-cache';
 
 export const dynamic = 'force-dynamic';
 
@@ -108,9 +109,14 @@ export async function GET(req: NextRequest) {
         );
       } catch (error) {
         if (isMissingDocumentBlobError(error)) {
+          await deleteDocumentTtsSegmentCache({
+            userId: doc.userId,
+            documentId: id,
+            namespace: testNamespace,
+          });
           await db
             .delete(documents)
-            .where(and(eq(documents.id, id), inArray(documents.userId, allowedUserIds)));
+            .where(and(eq(documents.id, id), eq(documents.userId, doc.userId)));
           return NextResponse.json({ error: 'Not found' }, { status: 404 });
         }
         throw error;

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -13,6 +13,7 @@ import {
 import { deleteDocumentBlob, isMissingBlobError, isValidDocumentId } from '@/lib/server/documents/blobstore';
 import { getOpenReaderTestNamespace } from '@/lib/server/testing/test-namespace';
 import { isS3Configured } from '@/lib/server/storage/s3';
+import { deleteDocumentTtsSegmentCache } from '@/lib/server/tts/segments-cache';
 import type { BaseDocument, DocumentType } from '@/types/documents';
 
 export const dynamic = 'force-dynamic';
@@ -134,6 +135,25 @@ export async function DELETE(req: NextRequest) {
 
     if (targetIds.length === 0) {
       return NextResponse.json({ success: true, deleted: 0 });
+    }
+
+    const ownedRows = (await db
+      .select({ id: documents.id, userId: documents.userId })
+      .from(documents)
+      .where(and(inArray(documents.userId, targetUserIds), inArray(documents.id, targetIds)))) as Array<{
+      id: string;
+      userId: string;
+    }>;
+
+    // TTS audio is user-scoped even when the underlying document blob is
+    // shared. Remove it before deleting ownership metadata so failures remain
+    // retryable and cannot create untraceable S3 objects.
+    for (const row of ownedRows) {
+      await deleteDocumentTtsSegmentCache({
+        userId: row.userId,
+        documentId: row.id,
+        namespace: testNamespace,
+      });
     }
 
     const deletedRows = (await db

--- a/src/app/api/tts/segments/ensure/route.ts
+++ b/src/app/api/tts/segments/ensure/route.ts
@@ -644,7 +644,7 @@ export async function POST(request: NextRequest) {
           instructions: effectiveSettings.ttsInstructions,
           language: effectiveSettings.language,
           provider: requestCreds.provider,
-          apiKey: requestCreds.apiKey || 'none',
+          apiKey: requestCreds.apiKey,
           baseUrl: requestCreds.baseUrl,
           testNamespace: scope.testNamespace,
         }, request.signal, {

--- a/src/app/api/tts/voices/route.ts
+++ b/src/app/api/tts/voices/route.ts
@@ -62,7 +62,7 @@ export async function GET(req: NextRequest) {
     const voices = await resolveVoices({
       provider: resolved.provider,
       model: requestedModel,
-      apiKey: resolved.apiKey || 'none',
+      apiKey: resolved.apiKey,
       baseUrl: resolved.baseUrl,
     });
     return NextResponse.json({ voices });

--- a/src/app/api/user/export/route.ts
+++ b/src/app/api/user/export/route.ts
@@ -2,12 +2,26 @@ import { NextRequest, NextResponse } from 'next/server';
 import { PassThrough, Readable } from 'stream';
 import { auth } from '@/lib/server/auth/auth';
 import { db } from '@/db';
-import { documents, audiobooks, audiobookChapters, userPreferences, userDocumentProgress, userTtsChars } from '@/db/schema';
+import {
+  documents,
+  audiobooks,
+  audiobookChapters,
+  documentSettings,
+  ttsSegmentEntries,
+  ttsSegmentVariants,
+  userDocumentProgress,
+  userJobEvents,
+  userPreferences,
+  userTtsChars,
+} from '@/db/schema';
+import * as authSchemaSqlite from '@/db/schema_auth_sqlite';
+import * as authSchemaPostgres from '@/db/schema_auth_postgres';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import archiver from 'archiver';
 import { appendUserExportArchive } from '@/lib/server/user/data-export';
 import { getDocumentBlobStream } from '@/lib/server/documents/blobstore';
 import { getAudiobookObjectStream, listAudiobookObjects } from '@/lib/server/audiobooks/blobstore';
+import { getTtsSegmentAudioObjectStream } from '@/lib/server/tts/segments-blobstore';
 import { isS3Configured } from '@/lib/server/storage/s3';
 import { getOpenReaderTestNamespace } from '@/lib/server/testing/test-namespace';
 import { nowTimestampMs } from '@/lib/shared/timestamps';
@@ -17,13 +31,6 @@ import { errorResponse } from '@/lib/server/errors/next-response';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  if (!isS3Configured()) {
-    return NextResponse.json(
-      { error: 'Export storage is not configured. Set S3_* environment variables.' },
-      { status: 503 },
-    );
-  }
-
   if (!auth) {
     return errorResponse(new Error('Auth not initialized'), {
       apiErrorMessage: 'Auth not initialized',
@@ -41,11 +48,21 @@ export async function GET(req: NextRequest) {
 
   const userId = session.user.id;
   const testNamespace = getOpenReaderTestNamespace(req.headers);
+  const storageEnabled = isS3Configured();
+  const requireStorage = () => {
+    if (!storageEnabled) {
+      throw new Error('Storage is not configured; file content could not be exported');
+    }
+  };
 
   const [
     prefs,
     progress,
     ttsUsage,
+    jobEvents,
+    perDocumentSettings,
+    segmentEntries,
+    segmentVariants,
     userDocs,
     userAudiobooks,
   ] = await Promise.all([
@@ -62,6 +79,26 @@ export async function GET(req: NextRequest) {
       .orderBy(desc(userTtsChars.date)),
     db
       .select()
+      .from(userJobEvents)
+      .where(eq(userJobEvents.userId, userId))
+      .orderBy(desc(userJobEvents.createdAt)),
+    db
+      .select()
+      .from(documentSettings)
+      .where(eq(documentSettings.userId, userId))
+      .orderBy(desc(documentSettings.updatedAt)),
+    db
+      .select()
+      .from(ttsSegmentEntries)
+      .where(eq(ttsSegmentEntries.userId, userId))
+      .orderBy(desc(ttsSegmentEntries.updatedAt)),
+    db
+      .select()
+      .from(ttsSegmentVariants)
+      .where(eq(ttsSegmentVariants.userId, userId))
+      .orderBy(desc(ttsSegmentVariants.updatedAt)),
+    db
+      .select()
       .from(documents)
       .where(eq(documents.userId, userId))
       .orderBy(desc(documents.lastModified)),
@@ -70,6 +107,36 @@ export async function GET(req: NextRequest) {
       .from(audiobooks)
       .where(eq(audiobooks.userId, userId))
       .orderBy(desc(audiobooks.createdAt)),
+  ]);
+
+  const authSchema = process.env.POSTGRES_URL ? authSchemaPostgres : authSchemaSqlite;
+  // Auth exports intentionally select metadata only. Credential and session
+  // secrets must never be written into the archive.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const database = db as any;
+  const [authSessions, linkedAccounts] = await Promise.all([
+    database
+      .select({
+        id: authSchema.session.id,
+        expiresAt: authSchema.session.expiresAt,
+        createdAt: authSchema.session.createdAt,
+        updatedAt: authSchema.session.updatedAt,
+        ipAddress: authSchema.session.ipAddress,
+        userAgent: authSchema.session.userAgent,
+      })
+      .from(authSchema.session)
+      .where(eq(authSchema.session.userId, userId)),
+    database
+      .select({
+        id: authSchema.account.id,
+        accountId: authSchema.account.accountId,
+        providerId: authSchema.account.providerId,
+        scope: authSchema.account.scope,
+        createdAt: authSchema.account.createdAt,
+        updatedAt: authSchema.account.updatedAt,
+      })
+      .from(authSchema.account)
+      .where(eq(authSchema.account.userId, userId)),
   ]);
 
   const archive = archiver('zip', {
@@ -114,7 +181,6 @@ export async function GET(req: NextRequest) {
       const exportedAtMs = nowTimestampMs();
       const profileData = {
         user: session.user,
-        session: session.session,
         exportedAtMs,
       };
 
@@ -126,13 +192,31 @@ export async function GET(req: NextRequest) {
         preferences: prefs[0] ?? null,
         readingHistory: progress,
         ttsUsage,
+        jobEvents,
+        documentSettings: perDocumentSettings,
+        authSessions,
+        linkedAccounts,
         documents: userDocs,
         audiobooks: userAudiobooks,
         audiobookChapters: allChapters,
-        getDocumentBlobStream: async (documentId: string) => getDocumentBlobStream(documentId, testNamespace),
-        listAudiobookObjects: async (bookId: string, ownerId: string) => listAudiobookObjects(bookId, ownerId, testNamespace),
-        getAudiobookObjectStream: async (bookId: string, ownerId: string, fileName: string) =>
-          getAudiobookObjectStream(bookId, ownerId, fileName, testNamespace),
+        ttsSegmentEntries: segmentEntries,
+        ttsSegmentVariants: segmentVariants,
+        getDocumentBlobStream: async (documentId: string) => {
+          requireStorage();
+          return getDocumentBlobStream(documentId, testNamespace);
+        },
+        listAudiobookObjects: async (bookId: string, ownerId: string) => {
+          requireStorage();
+          return listAudiobookObjects(bookId, ownerId, testNamespace);
+        },
+        getAudiobookObjectStream: async (bookId: string, ownerId: string, fileName: string) => {
+          requireStorage();
+          return getAudiobookObjectStream(bookId, ownerId, fileName, testNamespace);
+        },
+        getTtsSegmentAudioStream: async (audioKey: string) => {
+          requireStorage();
+          return (await getTtsSegmentAudioObjectStream(audioKey)).stream;
+        },
       });
 
       if (!req.signal.aborted) {

--- a/src/app/api/user/state/preferences/route.ts
+++ b/src/app/api/user/state/preferences/route.ts
@@ -2,15 +2,17 @@ import { NextRequest, NextResponse } from 'next/server';
 import { eq } from 'drizzle-orm';
 import { db } from '@/db';
 import { userPreferences } from '@/db/schema';
-import { SYNCED_PREFERENCE_KEYS, type SyncedPreferencesPatch } from '@/types/user-state';
+import { type SyncedPreferencesPatch } from '@/types/user-state';
 import { resolveUserStateScope } from '@/lib/server/user/resolve-state-scope';
 import { coerceTimestampMs, nowTimestampMs } from '@/lib/shared/timestamps';
-import { isTtsProviderType, type TtsProviderId } from '@/lib/shared/tts-provider-catalog';
 import { listAdminProviders } from '@/lib/server/admin/providers';
 import { getResolvedRuntimeConfig } from '@/lib/server/runtime-config';
-import { normalizeLegacyProviderRef, resolveProviderDefaults } from '@/lib/shared/tts-provider-policy';
 import { errorToLog, serverLogger } from '@/lib/server/logger';
 import { errorResponse } from '@/lib/server/errors/next-response';
+import {
+  sanitizePreferencesPatch,
+  type PreferenceNormalizationContext,
+} from '@/lib/server/user/preferences-normalize';
 import {
   deserializeUserPreferencesPayload,
   extractUserPreferencesMeta,
@@ -25,29 +27,14 @@ function serializePreferencesForDb(payload: Record<string, unknown>): Record<str
   return JSON.stringify(payload);
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-interface PreferenceNormalizationContext {
-  defaultProviderRef: string;
-  showAllProviderModels: boolean;
-  sharedProviders: Array<{
-    slug: string;
-    providerType: TtsProviderId;
-    defaultModel: string | null;
-    defaultInstructions: string | null;
-  }>;
-}
-
 async function loadPreferenceNormalizationContext(): Promise<PreferenceNormalizationContext> {
   const [runtimeConfig, providers] = await Promise.all([
     getResolvedRuntimeConfig(),
     listAdminProviders(),
   ]);
   return {
-    defaultProviderRef: runtimeConfig.defaultTtsProvider,
     showAllProviderModels: runtimeConfig.showAllProviderModels,
+    restrictUserApiKeys: runtimeConfig.restrictUserApiKeys,
     sharedProviders: providers
       .filter((entry) => entry.enabled)
       .map((entry) => ({
@@ -67,128 +54,6 @@ function parseStoredPreferences(
   const meta = extractUserPreferencesMeta(payload);
   const sanitized = sanitizePreferencesPatch(payload, context, { fillMissingProvider: true });
   return { ...sanitized, meta };
-}
-
-function sanitizeSavedVoices(value: unknown): Record<string, string> {
-  if (!isRecord(value)) return {};
-  const out: Record<string, string> = {};
-  for (const [key, val] of Object.entries(value)) {
-    if (typeof key !== 'string' || key.length === 0) continue;
-    if (typeof val !== 'string') continue;
-    out[key] = val;
-  }
-  return out;
-}
-
-function sanitizePreferencesPatch(
-  input: unknown,
-  context: PreferenceNormalizationContext,
-  options: { fillMissingProvider: boolean },
-): { patch: SyncedPreferencesPatch; migrated: boolean } {
-  if (!isRecord(input)) return { patch: {}, migrated: false };
-
-  const rec = input as Record<string, unknown>;
-  const out: SyncedPreferencesPatch = {};
-  let migrated = false;
-
-  const legacyProviderRef = typeof rec.ttsProvider === 'string'
-    ? rec.ttsProvider
-    : typeof rec.provider === 'string'
-      ? rec.provider
-      : '';
-  const rawProviderRef = typeof rec.providerRef === 'string' ? rec.providerRef : legacyProviderRef;
-  const normalizedProviderRef = normalizeLegacyProviderRef(rawProviderRef, context.defaultProviderRef);
-  const providerDefaults = resolveProviderDefaults({
-    providerRef: normalizedProviderRef || context.defaultProviderRef,
-    providerType: isTtsProviderType(rec.providerType) ? rec.providerType : 'unknown',
-    sharedProviders: context.sharedProviders,
-    fallbackProviderRef: context.defaultProviderRef,
-  });
-  const hasLegacyProviderKey = typeof rec.ttsProvider === 'string' || typeof rec.provider === 'string';
-  if (hasLegacyProviderKey || rawProviderRef !== providerDefaults.providerRef) migrated = true;
-
-  for (const key of SYNCED_PREFERENCE_KEYS) {
-    if (!(key in rec)) continue;
-    const value = rec[key];
-
-    switch (key) {
-      case 'viewType':
-        if (value === 'single' || value === 'dual' || value === 'scroll') out[key] = value;
-        break;
-      case 'voice':
-      case 'ttsModel':
-      case 'ttsInstructions':
-        if (typeof value === 'string') out[key] = value;
-        break;
-      case 'providerRef':
-        out[key] = providerDefaults.providerRef;
-        break;
-      case 'providerType':
-        out[key] = providerDefaults.providerType;
-        break;
-      case 'voiceSpeed':
-      case 'audioPlayerSpeed':
-      case 'segmentPreloadDepthPages':
-      case 'segmentPreloadSentenceLookahead':
-      case 'ttsSegmentMaxBlockLength':
-      case 'headerMargin':
-      case 'footerMargin':
-      case 'leftMargin':
-      case 'rightMargin':
-        if (Number.isFinite(value)) out[key] = Number(value);
-        break;
-      case 'skipBlank':
-      case 'epubTheme':
-      case 'pdfHighlightEnabled':
-      case 'pdfWordHighlightEnabled':
-      case 'epubHighlightEnabled':
-      case 'epubWordHighlightEnabled':
-      case 'htmlHighlightEnabled':
-      case 'htmlWordHighlightEnabled':
-        if (typeof value === 'boolean') out[key] = value;
-        break;
-      case 'savedVoices':
-        out[key] = sanitizeSavedVoices(value);
-        break;
-      default:
-        break;
-    }
-  }
-
-  if ('providerRef' in out && !('providerType' in out)) {
-    out.providerType = providerDefaults.providerType;
-    migrated = true;
-  }
-
-  if (options.fillMissingProvider && !('providerRef' in out)) {
-    out.providerRef = providerDefaults.providerRef;
-    migrated = true;
-  }
-  if (options.fillMissingProvider && !('providerType' in out)) {
-    out.providerType = providerDefaults.providerType;
-    migrated = true;
-  }
-
-  const rawModel = typeof rec.ttsModel === 'string' ? rec.ttsModel.trim() : '';
-  const shouldNormalizeSharedDefaultModel =
-    !!providerDefaults.defaultModel
-    && context.sharedProviders.some((entry) => entry.slug === providerDefaults.providerRef)
-    && (rawModel.length === 0 || rawModel === 'kokoro')
-    && (hasLegacyProviderKey || rawProviderRef === 'default-openai');
-
-  if (options.fillMissingProvider && !('ttsModel' in out) && providerDefaults.defaultModel) {
-    out.ttsModel = providerDefaults.defaultModel;
-    migrated = true;
-  } else if (shouldNormalizeSharedDefaultModel && out.ttsModel !== providerDefaults.defaultModel) {
-    out.ttsModel = providerDefaults.defaultModel;
-    migrated = true;
-  }
-  if (!context.showAllProviderModels && providerDefaults.defaultModel && out.ttsModel !== providerDefaults.defaultModel) {
-    out.ttsModel = providerDefaults.defaultModel;
-    migrated = true;
-  }
-
-  return { patch: out, migrated };
 }
 
 function normalizeClientUpdatedAtMs(value: unknown): number {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -37,6 +37,8 @@ import { useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 import { AdminProvidersPanel } from '@/components/admin/AdminProvidersPanel';
 import { AdminFeaturesPanel } from '@/components/admin/AdminFeaturesPanel';
 import { useSharedProviders } from '@/hooks/useSharedProviders';
+import { flushUserPreferencesSync } from '@/lib/client/api/user-state';
+import toast from 'react-hot-toast';
 import { useLibraryDocumentsQuery } from '@/hooks/useLibraryDocumentsQuery';
 import {
   SidebarNav,
@@ -265,7 +267,7 @@ export function SettingsModal({
     prefetch: prefetchLibraryDocuments,
   } = useLibraryDocumentsQuery(isSelectionModalOpen);
 
-  const { providers: sharedProviders } = useSharedProviders();
+  const { providers: sharedProviders, isLoading: sharedProvidersLoading } = useSharedProviders();
   const {
     providers: ttsProviders,
     models: ttsModels,
@@ -295,13 +297,18 @@ export function SettingsModal({
   }, [changelogOpenSignal, setIsOpen]);
 
   useEffect(() => {
+    // Only mirror persisted config into the local form while the modal is closed.
+    // While it's open the user may be mid-edit, and a background refresh (e.g. the
+    // focus refetch in ConfigContext, or async shared-provider loading) must not
+    // stomp their in-progress selection. On close, resetToCurrent re-syncs.
+    if (isOpen) return;
     setLocalApiKey(apiKey);
     setLocalBaseUrl(baseUrl);
     setLocalProviderRef(providerRef);
     setLocalProviderType(providerType);
     setModelValue(ttsModel);
     setLocalTTSInstructions(ttsInstructions);
-  }, [apiKey, baseUrl, providerRef, providerType, ttsModel, ttsInstructions]);
+  }, [isOpen, apiKey, baseUrl, providerRef, providerType, ttsModel, ttsInstructions]);
 
   useEffect(() => {
     if (!ttsModels.some(m => m.id === modelValue) && modelValue !== '') {
@@ -643,7 +650,9 @@ export function SettingsModal({
                         <div className="space-y-4">
                           <div className="space-y-1.5">
                             <label className={fieldLabelClass}>TTS Provider</label>
-                            {ttsProviders.length === 0 ? (
+                            {sharedProvidersLoading ? (
+                              <p className="text-xs text-soft">Loading providers…</p>
+                            ) : ttsProviders.length === 0 ? (
                               <p className="text-xs text-accent">
                                 User API keys are restricted and no shared provider is configured. Ask an admin to add one.
                               </p>
@@ -815,7 +824,7 @@ export function SettingsModal({
                               type="button"
                               variant="primary"
                               size="md"
-                              disabled={!canSubmit}
+                              disabled={!canSubmit || sharedProvidersLoading}
                               onClick={async () => {
                                 const defaults = resolveProviderDefaults({
                                   providerRef: selectedProviderRef,
@@ -833,6 +842,16 @@ export function SettingsModal({
                                   : defaults.defaultModel;
                                 await updateConfigKey('ttsModel', finalModel);
                                 await updateConfigKey('ttsInstructions', localTTSInstructions);
+                                // Push the change to the server immediately rather than waiting on
+                                // the debounce, so a quick reload can't lose the save. Surface
+                                // failures instead of silently dropping them.
+                                try {
+                                  await flushUserPreferencesSync();
+                                } catch (error) {
+                                  console.error('Failed to save TTS provider settings:', error);
+                                  toast.error('Failed to save provider settings. Please try again.');
+                                  return;
+                                }
                                 setIsOpen(false);
                               }}
                             >

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -5,11 +5,11 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { db, initDB, migrateLegacyDexieDocumentIdsToSha, updateAppConfig } from '@/lib/client/dexie';
 import { APP_CONFIG_DEFAULTS, type ViewType, type SavedVoices, type AppConfigValues, type AppConfigRow } from '@/types/config';
 import { isBuiltInTtsProviderId } from '@/lib/shared/tts-provider-catalog';
-import { resolveEffectiveProviderType, resolveProviderDefaults } from '@/lib/shared/tts-provider-policy';
+import { resolveProviderDefaults } from '@/lib/shared/tts-provider-policy';
 import { scheduleUserPreferencesSync, cancelPendingPreferenceSync, getUserPreferences, putUserPreferences } from '@/lib/client/api/user-state';
 import { SYNCED_PREFERENCE_KEYS, type SyncedPreferenceKey, type SyncedPreferencesPatch } from '@/types/user-state';
 import { useAuthSession } from '@/hooks/useAuthSession';
-import { useFeatureFlag } from '@/contexts/RuntimeConfigContext';
+import { useFeatureFlag, useRuntimeConfig } from '@/contexts/RuntimeConfigContext';
 import { buildSyncedPreferencePatch } from '@/lib/client/config/preferences';
 import { applyConfigUpdate } from '@/lib/client/config/updates';
 import { useSharedProviders } from '@/hooks/useSharedProviders';
@@ -69,16 +69,12 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   const didRunStartupMigrations = useRef(false);
   const didAttemptInitialPreferenceSeedForSession = useRef<string | null>(null);
   const syncedPreferenceKeys = useMemo(() => new Set<string>(SYNCED_PREFERENCE_KEYS), []);
-  const { providers: sharedProviders } = useSharedProviders();
+  const { providers: sharedProviders, isLoading: sharedProvidersLoading } = useSharedProviders();
   const { data: sessionData, isPending: isSessionPending } = useAuthSession();
   const sessionKey = sessionData?.user?.id ?? 'no-session';
-  const providerResetDefaults = useMemo(() => {
-    return resolveProviderDefaults({
-      providerRef: APP_CONFIG_DEFAULTS.providerRef,
-      providerType: APP_CONFIG_DEFAULTS.providerType,
-      sharedProviders,
-    });
-  }, [sharedProviders]);
+  // The instance/admin default provider. An empty user providerRef "inherits"
+  // this, resolved (admin slug -> concrete provider) where the value is used.
+  const adminDefaultProviderRef = useRuntimeConfig().defaultTtsProvider;
 
   const queueSyncedPreferencePatch = useCallback((patch: Partial<AppConfigValues>) => {
     if (sessionKey === 'no-session') return;
@@ -213,28 +209,18 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   }, [appConfig]);
 
   useEffect(() => {
-    if (!ttsProvidersTabDisabled || !isDBReady || !appConfig) return;
+    if (!ttsProvidersTabDisabled || !isDBReady || !appConfig || sharedProvidersLoading) return;
 
     const resetPatch: Partial<AppConfigRow> = {};
 
-    if (appConfig.apiKey !== APP_CONFIG_DEFAULTS.apiKey) {
-      resetPatch.apiKey = APP_CONFIG_DEFAULTS.apiKey;
-    }
-    if (appConfig.baseUrl !== APP_CONFIG_DEFAULTS.baseUrl) {
-      resetPatch.baseUrl = APP_CONFIG_DEFAULTS.baseUrl;
-    }
-    if (appConfig.providerRef !== providerResetDefaults.providerRef) {
-      resetPatch.providerRef = providerResetDefaults.providerRef;
-    }
-    if (appConfig.providerType !== providerResetDefaults.providerType) {
-      resetPatch.providerType = providerResetDefaults.providerType;
-    }
-    if (appConfig.ttsModel !== providerResetDefaults.defaultModel) {
-      resetPatch.ttsModel = providerResetDefaults.defaultModel;
-    }
-    if (appConfig.ttsInstructions !== providerResetDefaults.defaultInstructions) {
-      resetPatch.ttsInstructions = providerResetDefaults.defaultInstructions;
-    }
+    // When the provider tab is hidden, clear any user-set provider config back to
+    // "inherit the admin default" (empty) rather than baking in a concrete value.
+    if (appConfig.apiKey !== '') resetPatch.apiKey = '';
+    if (appConfig.baseUrl !== '') resetPatch.baseUrl = '';
+    if (appConfig.providerRef !== '') resetPatch.providerRef = '';
+    if (appConfig.providerType !== 'unknown') resetPatch.providerType = 'unknown';
+    if (appConfig.ttsModel !== '') resetPatch.ttsModel = '';
+    if (appConfig.ttsInstructions !== '') resetPatch.ttsInstructions = '';
     // Keep voice selection state intact so player/Audiobook voice pickers still
     // work when the TTS providers tab is hidden. This reset is only for provider
     // configuration fields.
@@ -245,32 +231,24 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       console.warn('Failed to clear hidden TTS provider settings:', error);
     });
     queueSyncedPreferencePatch(resetPatch);
-  }, [ttsProvidersTabDisabled, isDBReady, appConfig, queueSyncedPreferencePatch, providerResetDefaults]);
+  }, [ttsProvidersTabDisabled, isDBReady, appConfig, queueSyncedPreferencePatch, sharedProvidersLoading]);
 
   useEffect(() => {
-    if (!restrictUserApiKeys || !isDBReady || !appConfig) return;
+    if (!restrictUserApiKeys || !isDBReady || !appConfig || sharedProvidersLoading) return;
 
     const resetPatch: Partial<AppConfigRow> = {};
 
-    if (appConfig.apiKey !== APP_CONFIG_DEFAULTS.apiKey) {
-      resetPatch.apiKey = APP_CONFIG_DEFAULTS.apiKey;
-    }
-    if (appConfig.baseUrl !== APP_CONFIG_DEFAULTS.baseUrl) {
-      resetPatch.baseUrl = APP_CONFIG_DEFAULTS.baseUrl;
-    }
+    if (appConfig.apiKey !== '') resetPatch.apiKey = '';
+    if (appConfig.baseUrl !== '') resetPatch.baseUrl = '';
+    // Built-in providers aren't selectable in restricted mode. Clear any stale
+    // built-in selection (including the old 'custom-openai' default that used to
+    // be baked into every config) back to "inherit the admin default" so the
+    // user follows whatever shared provider the admin has configured.
     if (isBuiltInTtsProviderId(appConfig.providerRef)) {
-      if (appConfig.providerRef !== providerResetDefaults.providerRef) {
-        resetPatch.providerRef = providerResetDefaults.providerRef;
-      }
-      if (appConfig.providerType !== providerResetDefaults.providerType) {
-        resetPatch.providerType = providerResetDefaults.providerType;
-      }
-      if (appConfig.ttsModel !== providerResetDefaults.defaultModel) {
-        resetPatch.ttsModel = providerResetDefaults.defaultModel;
-      }
-      if (appConfig.ttsInstructions !== providerResetDefaults.defaultInstructions) {
-        resetPatch.ttsInstructions = providerResetDefaults.defaultInstructions;
-      }
+      resetPatch.providerRef = '';
+      resetPatch.providerType = 'unknown';
+      resetPatch.ttsModel = '';
+      resetPatch.ttsInstructions = '';
     }
 
     if (Object.keys(resetPatch).length === 0) return;
@@ -279,15 +257,18 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       console.warn('Failed to enforce restricted user API key mode:', error);
     });
     queueSyncedPreferencePatch(resetPatch);
-  }, [restrictUserApiKeys, isDBReady, appConfig, queueSyncedPreferencePatch, providerResetDefaults]);
+  }, [restrictUserApiKeys, isDBReady, appConfig, queueSyncedPreferencePatch, sharedProvidersLoading]);
 
   useEffect(() => {
-    if (showAllProviderModels || !isDBReady || !appConfig) return;
+    if (showAllProviderModels || !isDBReady || !appConfig || sharedProvidersLoading) return;
+    // Inheriting (empty providerRef): the effective model is resolved at read
+    // time, so there is nothing to persist/enforce here.
+    if (!appConfig.providerRef) return;
     const providerDefaults = resolveProviderDefaults({
       providerRef: appConfig.providerRef,
       providerType: appConfig.providerType,
       sharedProviders,
-      fallbackProviderRef: providerResetDefaults.providerRef,
+      fallbackProviderRef: adminDefaultProviderRef,
     });
     if (!providerDefaults.defaultModel) return;
     if (appConfig.ttsModel === providerDefaults.defaultModel) return;
@@ -296,7 +277,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       console.warn('Failed to enforce provider default model restriction:', error);
     });
     queueSyncedPreferencePatch(patch);
-  }, [showAllProviderModels, isDBReady, appConfig, sharedProviders, providerResetDefaults.providerRef, queueSyncedPreferencePatch]);
+  }, [showAllProviderModels, isDBReady, appConfig, sharedProviders, adminDefaultProviderRef, queueSyncedPreferencePatch, sharedProvidersLoading]);
 
   useEffect(() => {
     if (!isDBReady || !appConfig || isSessionPending) return;
@@ -359,33 +340,48 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     htmlHighlightEnabled,
     htmlWordHighlightEnabled,
   } = config || APP_CONFIG_DEFAULTS;
-  const providerType = useMemo(
-    () => resolveEffectiveProviderType({
+  // Resolve the effective provider for consumers. An empty stored providerRef
+  // means "inherit the admin default", which we resolve here so the reader,
+  // voice pickers, and settings UI all see a concrete, usable provider without
+  // mutating the stored ("inherit") value.
+  const effectiveProvider = useMemo(
+    () => resolveProviderDefaults({
       providerRef,
       providerType: _persistedProviderType,
       sharedProviders,
+      fallbackProviderRef: adminDefaultProviderRef,
     }),
-    [providerRef, _persistedProviderType, sharedProviders],
+    [providerRef, _persistedProviderType, sharedProviders, adminDefaultProviderRef],
   );
+  const effectiveProviderRef = effectiveProvider.providerRef;
+  const providerType = effectiveProvider.providerType;
+  const effectiveTtsModel = ttsModel || effectiveProvider.defaultModel;
+  const effectiveTtsInstructions = ttsInstructions || effectiveProvider.defaultInstructions;
 
   useEffect(() => {
-    if (!isDBReady || !appConfig) return;
+    if (!isDBReady || !appConfig || sharedProvidersLoading) return;
+    // Only persist a resolved providerType for an explicitly chosen provider.
+    // While inheriting (empty providerRef) the type stays unset in storage.
+    if (!appConfig.providerRef) return;
     if (appConfig.providerType === providerType) return;
     const patch: Partial<AppConfigRow> = { providerType };
     updateAppConfig(patch).catch((error) => {
       console.warn('Failed to persist resolved providerType:', error);
     });
     queueSyncedPreferencePatch(patch);
-  }, [isDBReady, appConfig, providerType, queueSyncedPreferencePatch]);
+  }, [isDBReady, appConfig, providerType, queueSyncedPreferencePatch, sharedProvidersLoading]);
   void _persistedProviderType;
 
   useEffect(() => {
-    if (!isDBReady || !appConfig) return;
+    if (!isDBReady || !appConfig || sharedProvidersLoading) return;
+    // Inheriting (empty providerRef): the effective model is resolved at read
+    // time; don't write a concrete model into the "inherit" state.
+    if (!appConfig.providerRef) return;
     const providerDefaults = resolveProviderDefaults({
       providerRef: appConfig.providerRef,
       providerType: appConfig.providerType,
       sharedProviders,
-      fallbackProviderRef: providerResetDefaults.providerRef,
+      fallbackProviderRef: adminDefaultProviderRef,
     });
     if (!providerDefaults.defaultModel) return;
     if (appConfig.ttsModel === providerDefaults.defaultModel) return;
@@ -398,7 +394,7 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       console.warn('Failed to normalize shared-provider default model:', error);
     });
     queueSyncedPreferencePatch(patch);
-  }, [isDBReady, appConfig, sharedProviders, queueSyncedPreferencePatch, providerResetDefaults.providerRef]);
+  }, [isDBReady, appConfig, sharedProviders, queueSyncedPreferencePatch, adminDefaultProviderRef, sharedProvidersLoading]);
 
   /**
    * Updates multiple configuration values simultaneously
@@ -436,9 +432,9 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
     try {
       setIsLoading(true);
       const { storagePatch, syncPatch } = applyConfigUpdate({
-        providerRef,
+        providerRef: effectiveProviderRef,
         providerType,
-        ttsModel,
+        ttsModel: effectiveTtsModel,
         savedVoices,
       }, key, value);
 
@@ -478,10 +474,10 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
       footerMargin,
       leftMargin,
       rightMargin,
-      providerRef,
+      providerRef: effectiveProviderRef,
       providerType,
-      ttsModel,
-      ttsInstructions,
+      ttsModel: effectiveTtsModel,
+      ttsInstructions: effectiveTtsInstructions,
       savedVoices,
       updateConfig,
       updateConfigKey,

--- a/src/contexts/ConfigContext.tsx
+++ b/src/contexts/ConfigContext.tsx
@@ -209,54 +209,54 @@ export function ConfigProvider({ children }: { children: ReactNode }) {
   }, [appConfig]);
 
   useEffect(() => {
-    if (!ttsProvidersTabDisabled || !isDBReady || !appConfig || sharedProvidersLoading) return;
+    if (ttsProvidersTabDisabled && isDBReady && appConfig && !sharedProvidersLoading) {
+      const resetPatch: Partial<AppConfigRow> = {};
 
-    const resetPatch: Partial<AppConfigRow> = {};
+      // When the provider tab is hidden, clear any user-set provider config back to
+      // "inherit the admin default" (empty) rather than baking in a concrete value.
+      if (appConfig.apiKey !== '') resetPatch.apiKey = '';
+      if (appConfig.baseUrl !== '') resetPatch.baseUrl = '';
+      if (appConfig.providerRef !== '') resetPatch.providerRef = '';
+      if (appConfig.providerType !== 'unknown') resetPatch.providerType = 'unknown';
+      if (appConfig.ttsModel !== '') resetPatch.ttsModel = '';
+      if (appConfig.ttsInstructions !== '') resetPatch.ttsInstructions = '';
+      // Keep voice selection state intact so player/Audiobook voice pickers still
+      // work when the TTS providers tab is hidden. This reset is only for provider
+      // configuration fields.
 
-    // When the provider tab is hidden, clear any user-set provider config back to
-    // "inherit the admin default" (empty) rather than baking in a concrete value.
-    if (appConfig.apiKey !== '') resetPatch.apiKey = '';
-    if (appConfig.baseUrl !== '') resetPatch.baseUrl = '';
-    if (appConfig.providerRef !== '') resetPatch.providerRef = '';
-    if (appConfig.providerType !== 'unknown') resetPatch.providerType = 'unknown';
-    if (appConfig.ttsModel !== '') resetPatch.ttsModel = '';
-    if (appConfig.ttsInstructions !== '') resetPatch.ttsInstructions = '';
-    // Keep voice selection state intact so player/Audiobook voice pickers still
-    // work when the TTS providers tab is hidden. This reset is only for provider
-    // configuration fields.
+      if (Object.keys(resetPatch).length === 0) return;
 
-    if (Object.keys(resetPatch).length === 0) return;
-
-    updateAppConfig(resetPatch).catch((error) => {
-      console.warn('Failed to clear hidden TTS provider settings:', error);
-    });
-    queueSyncedPreferencePatch(resetPatch);
+      updateAppConfig(resetPatch).catch((error) => {
+        console.warn('Failed to clear hidden TTS provider settings:', error);
+      });
+      queueSyncedPreferencePatch(resetPatch);
+    }
   }, [ttsProvidersTabDisabled, isDBReady, appConfig, queueSyncedPreferencePatch, sharedProvidersLoading]);
 
   useEffect(() => {
-    if (!restrictUserApiKeys || !isDBReady || !appConfig || sharedProvidersLoading) return;
+    if (restrictUserApiKeys && isDBReady && appConfig && !sharedProvidersLoading) {
+      const resetPatch: Partial<AppConfigRow> = {};
 
-    const resetPatch: Partial<AppConfigRow> = {};
+      if (appConfig.apiKey !== '') resetPatch.apiKey = '';
+      if (appConfig.baseUrl !== '') resetPatch.baseUrl = '';
+      // Built-in providers aren't selectable in restricted mode. Clear any stale
+      // built-in selection (including the old 'custom-openai' default that used to
+      // be baked into every config) back to "inherit the admin default" so the
+      // user follows whatever shared provider the admin has configured.
+      if (isBuiltInTtsProviderId(appConfig.providerRef)) {
+        resetPatch.providerRef = '';
+        resetPatch.providerType = 'unknown';
+        resetPatch.ttsModel = '';
+        resetPatch.ttsInstructions = '';
+      }
 
-    if (appConfig.apiKey !== '') resetPatch.apiKey = '';
-    if (appConfig.baseUrl !== '') resetPatch.baseUrl = '';
-    // Built-in providers aren't selectable in restricted mode. Clear any stale
-    // built-in selection (including the old 'custom-openai' default that used to
-    // be baked into every config) back to "inherit the admin default" so the
-    // user follows whatever shared provider the admin has configured.
-    if (isBuiltInTtsProviderId(appConfig.providerRef)) {
-      resetPatch.providerRef = '';
-      resetPatch.providerType = 'unknown';
-      resetPatch.ttsModel = '';
-      resetPatch.ttsInstructions = '';
+      if (Object.keys(resetPatch).length === 0) return;
+
+      updateAppConfig(resetPatch).catch((error) => {
+        console.warn('Failed to enforce restricted user API key mode:', error);
+      });
+      queueSyncedPreferencePatch(resetPatch);
     }
-
-    if (Object.keys(resetPatch).length === 0) return;
-
-    updateAppConfig(resetPatch).catch((error) => {
-      console.warn('Failed to enforce restricted user API key mode:', error);
-    });
-    queueSyncedPreferencePatch(resetPatch);
   }, [restrictUserApiKeys, isDBReady, appConfig, queueSyncedPreferencePatch, sharedProvidersLoading]);
 
   useEffect(() => {

--- a/src/db/schema_postgres.ts
+++ b/src/db/schema_postgres.ts
@@ -54,7 +54,7 @@ export const audiobookChapters = pgTable('audiobook_chapters', {
 // defined here. Only application-specific tables belong in this file.
 
 export const userTtsChars = pgTable("user_tts_chars", {
-  userId: text('user_id').notNull(),
+  userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
   date: date('date').notNull(),
   charCount: bigint('char_count', { mode: 'number' }).default(0),
   createdAt: bigint('created_at', { mode: 'number' }).default(PG_NOW_MS),
@@ -71,7 +71,7 @@ export const userTtsChars = pgTable("user_tts_chars", {
 // worker bounds each op by a hard cap, "ops created in the last hard-cap
 // window" is an upper bound on in-flight ops. Old rows are pruned opportunistically.
 export const userJobEvents = pgTable('user_job_events', {
-  userId: text('user_id').notNull(),
+  userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
   action: text('action').notNull(),
   opId: text('op_id').notNull(),
   createdAt: bigint('created_at', { mode: 'number' }).notNull().default(PG_NOW_MS),

--- a/src/db/schema_sqlite.ts
+++ b/src/db/schema_sqlite.ts
@@ -54,7 +54,7 @@ export const audiobookChapters = sqliteTable('audiobook_chapters', {
 // defined here. Only application-specific tables belong in this file.
 
 export const userTtsChars = sqliteTable("user_tts_chars", {
-  userId: text('user_id').notNull(),
+  userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
   date: text('date').notNull(), // SQLite doesn't have native DATE type, text YYYY-MM-DD is standard
   charCount: integer('char_count').default(0),
   createdAt: integer('created_at').default(SQLITE_NOW_MS),
@@ -71,7 +71,7 @@ export const userTtsChars = sqliteTable("user_tts_chars", {
 // worker bounds each op by a hard cap, "ops created in the last hard-cap
 // window" is an upper bound on in-flight ops. Old rows are pruned opportunistically.
 export const userJobEvents = sqliteTable('user_job_events', {
-  userId: text('user_id').notNull(),
+  userId: text('user_id').notNull().references(() => user.id, { onDelete: 'cascade' }),
   action: text('action').notNull(),
   opId: text('op_id').notNull(),
   createdAt: integer('created_at').notNull().default(SQLITE_NOW_MS),

--- a/src/lib/client/api/user-state.ts
+++ b/src/lib/client/api/user-state.ts
@@ -148,6 +148,32 @@ export function scheduleUserPreferencesSync(
   }, debounceMs);
 }
 
+/**
+ * Immediately send any pending debounced preference patch and await the result.
+ * Use this when the user explicitly saves: we want the server write to complete
+ * (and surface failures) instead of silently relying on the debounce timer, which
+ * can be lost if the page is reloaded inside the debounce window.
+ */
+export async function flushUserPreferencesSync(): Promise<void> {
+  if (pendingPreferenceSync.timer) {
+    clearTimeout(pendingPreferenceSync.timer);
+    pendingPreferenceSync.timer = null;
+  }
+
+  const payload = { ...pendingPreferenceSync.patch };
+  pendingPreferenceSync.patch = {};
+  if (Object.keys(payload).length === 0) return;
+
+  if (activeSyncController) activeSyncController.abort();
+  activeSyncController = new AbortController();
+
+  try {
+    await putUserPreferences(payload, { signal: activeSyncController.signal });
+  } finally {
+    activeSyncController = null;
+  }
+}
+
 export async function getDocumentProgress(
   documentId: string,
   options?: { signal?: AbortSignal },

--- a/src/lib/server/admin/seed.ts
+++ b/src/lib/server/admin/seed.ts
@@ -32,7 +32,7 @@ type SeedProviderInput = {
   slug: string;
   displayName: string;
   providerType: TtsProviderId;
-  apiKey: string;
+  apiKey?: string;
   baseUrl?: string | null;
   defaultModel?: string | null;
   defaultInstructions?: string | null;
@@ -187,8 +187,8 @@ function validateSeedProviderEntry(value: unknown, index: number): SeedProviderI
   if (typeof rec.providerType !== 'string') {
     throw new Error(`Seed JSON providers[${index}].providerType must be a string`);
   }
-  if (typeof rec.apiKey !== 'string' || !rec.apiKey.trim()) {
-    throw new Error(`Seed JSON providers[${index}].apiKey must be a non-empty string`);
+  if (rec.apiKey !== undefined && typeof rec.apiKey !== 'string') {
+    throw new Error(`Seed JSON providers[${index}].apiKey must be a string when provided`);
   }
 
   if (rec.baseUrl !== undefined && rec.baseUrl !== null && typeof rec.baseUrl !== 'string') {
@@ -208,7 +208,7 @@ function validateSeedProviderEntry(value: unknown, index: number): SeedProviderI
     slug: validateSlug(rec.slug),
     displayName: rec.displayName.trim(),
     providerType: validateProviderType(rec.providerType),
-    apiKey: rec.apiKey.trim(),
+    ...(rec.apiKey !== undefined ? { apiKey: rec.apiKey.trim() } : {}),
     ...(rec.baseUrl !== undefined ? { baseUrl: normalizeOptionalString(rec.baseUrl) } : {}),
     ...(rec.defaultModel !== undefined ? { defaultModel: normalizeOptionalString(rec.defaultModel) } : {}),
     ...(rec.defaultInstructions !== undefined ? { defaultInstructions: normalizeOptionalString(rec.defaultInstructions) } : {}),
@@ -246,7 +246,8 @@ async function seedAdminProvidersFromJson(providers: SeedProviderInput[]): Promi
     if (existing.length > 0) continue;
 
     try {
-      const encrypted = encryptSecret(provider.apiKey);
+      const apiKey = provider.apiKey ?? '';
+      const encrypted = encryptSecret(apiKey);
       await db.insert(adminProviders).values({
         id: randomUUID(),
         slug: provider.slug,
@@ -255,7 +256,7 @@ async function seedAdminProvidersFromJson(providers: SeedProviderInput[]): Promi
         baseUrl: provider.baseUrl ?? null,
         apiKeyCiphertext: encrypted.ciphertext,
         apiKeyIv: encrypted.iv,
-        apiKeyLast4: apiKeyLast4(provider.apiKey),
+        apiKeyLast4: apiKeyLast4(apiKey),
         defaultModel: provider.defaultModel ?? null,
         defaultInstructions: provider.defaultInstructions ?? null,
         enabled: provider.enabled === false ? 0 : 1,
@@ -278,8 +279,9 @@ async function seedAdminProvidersFromJson(providers: SeedProviderInput[]): Promi
 }
 
 async function seedDefaultAdminProviderFromEnvFallback(): Promise<void> {
-  const apiKey = process.env.API_KEY;
-  if (!apiKey || !apiKey.trim()) return;
+  const apiKey = process.env.API_KEY?.trim() ?? '';
+  const baseUrl = process.env.API_BASE?.trim() || null;
+  if (!apiKey && !baseUrl) return;
 
   let existing: Array<unknown>;
   try {
@@ -295,7 +297,6 @@ async function seedDefaultAdminProviderFromEnvFallback(): Promise<void> {
   }
   if (existing.length > 0) return;
 
-  const baseUrl = process.env.API_BASE?.trim() || null;
   const now = Date.now();
   let enc: ReturnType<typeof encryptSecret>;
   try {

--- a/src/lib/server/admin/settings.ts
+++ b/src/lib/server/admin/settings.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { asc, desc, eq } from 'drizzle-orm';
 import { db } from '@/db';
 import { adminProviders, adminSettings } from '@/db/schema';
 import { serverLogger } from '@/lib/server/logger';
@@ -116,9 +116,19 @@ async function resolveImplicitDefaultTtsProvider(): Promise<string | undefined> 
     const rows = await db
       .select({ slug: adminProviders.slug })
       .from(adminProviders)
-      .where(and(eq(adminProviders.slug, 'default-openai'), eq(adminProviders.enabled, 1)))
-      .limit(1);
-    return rows[0]?.slug;
+      .where(eq(adminProviders.enabled, 1))
+      .orderBy(
+        desc(adminProviders.updatedAt),
+        desc(adminProviders.createdAt),
+        asc(adminProviders.slug),
+      );
+    const slugs = (rows as Array<{ slug: string }>).map((row) => row.slug);
+    // Prefer the conventional 'default-openai' slug when present, otherwise fall
+    // back to the first enabled shared provider so a fresh instance with any
+    // configured provider resolves to a real, usable provider rather than the
+    // built-in 'custom-openai' placeholder.
+    if (slugs.includes('default-openai')) return 'default-openai';
+    return slugs[0];
   } catch (error) {
     logDegraded(serverLogger, {
       event: 'admin.runtime_config.default_provider_lookup.failed',

--- a/src/lib/server/audiobooks/blobstore.ts
+++ b/src/lib/server/audiobooks/blobstore.ts
@@ -255,7 +255,11 @@ export async function deleteAudiobookPrefix(prefix: string): Promise<number> {
           },
         }),
       );
-      deleted += deleteRes.Deleted?.length ?? 0;
+      const errors = deleteRes.Errors ?? [];
+      if (errors.length > 0) {
+        throw new Error(`Failed deleting ${errors.length} audiobook storage objects`);
+      }
+      deleted += keys.length;
     }
 
     continuationToken = listRes.IsTruncated ? listRes.NextContinuationToken : undefined;

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -96,8 +96,9 @@ const createAuth = () => betterAuth({
             context: { userIdHash: hashForLog(user.id) },
             error,
           });
-          // Don't throw – allow the user deletion to proceed even if S3 cleanup fails.
-          // Orphaned blobs are preferable to a blocked account deletion.
+          // Without a durable cleanup queue, proceeding would permanently
+          // orphan user-scoped storage and non-cascading database rows.
+          throw error;
         }
       },
     },

--- a/src/lib/server/documents/blobstore.ts
+++ b/src/lib/server/documents/blobstore.ts
@@ -507,10 +507,10 @@ export async function deleteDocumentBlob(id: string, namespace: string | null): 
   const parsedPrefix = `${cfg.prefix}/documents_v1/parsed_v2/${nsSegment}${id}/`;
 
   await client.send(new DeleteObjectCommand({ Bucket: cfg.bucket, Key: key }));
-  await client.send(new DeleteObjectCommand({ Bucket: cfg.bucket, Key: parsedKey })).catch(() => undefined);
-  await client.send(new DeleteObjectCommand({ Bucket: cfg.bucket, Key: legacyParsedKey })).catch(() => undefined);
-  await deleteDocumentPrefix(parsedPrefix).catch(() => undefined);
-  await deleteDocumentPrefix(`${key}/`).catch(() => undefined);
+  await client.send(new DeleteObjectCommand({ Bucket: cfg.bucket, Key: parsedKey }));
+  await client.send(new DeleteObjectCommand({ Bucket: cfg.bucket, Key: legacyParsedKey }));
+  await deleteDocumentPrefix(parsedPrefix);
+  await deleteDocumentPrefix(`${key}/`);
 }
 
 export async function deleteTempDocumentUpload(token: string, userId: string, namespace: string | null): Promise<void> {
@@ -564,7 +564,11 @@ export async function deleteDocumentPrefix(prefix: string): Promise<number> {
           },
         }),
       );
-      deleted += deleteRes.Deleted?.length ?? 0;
+      const errors = deleteRes.Errors ?? [];
+      if (errors.length > 0) {
+        throw new Error(`Failed deleting ${errors.length} document storage objects`);
+      }
+      deleted += keys.length;
     }
 
     continuationToken = listRes.IsTruncated ? listRes.NextContinuationToken : undefined;

--- a/src/lib/server/documents/register-upload.ts
+++ b/src/lib/server/documents/register-upload.ts
@@ -1,9 +1,11 @@
 import { db } from '@/db';
 import { documents } from '@/db/schema';
+import { and, eq } from 'drizzle-orm';
 import {
   enqueueDocumentPreview,
 } from '@/lib/server/documents/previews';
 import { errorToLog, serverLogger } from '@/lib/server/logger';
+import { deleteDocumentTtsSegmentCache } from '@/lib/server/tts/segments-cache';
 import type { BaseDocument, DocumentType } from '@/types/documents';
 
 type RegisterUploadedDocumentInput = {
@@ -17,6 +19,23 @@ type RegisterUploadedDocumentInput = {
 };
 
 export async function registerUploadedDocument(input: RegisterUploadedDocumentInput): Promise<BaseDocument> {
+  const [existing] = await db
+    .select({ lastModified: documents.lastModified })
+    .from(documents)
+    .where(and(
+      eq(documents.id, input.documentId),
+      eq(documents.userId, input.userId),
+    ))
+    .limit(1);
+
+  if (existing && Number(existing.lastModified) !== input.lastModified) {
+    await deleteDocumentTtsSegmentCache({
+      userId: input.userId,
+      documentId: input.documentId,
+      namespace: input.namespace,
+    });
+  }
+
   await db
     .insert(documents)
     .values({

--- a/src/lib/server/tts/generate.ts
+++ b/src/lib/server/tts/generate.ts
@@ -15,7 +15,11 @@ import { LRUCache } from 'lru-cache';
 import { createHash } from 'crypto';
 import { access, readFile } from 'fs/promises';
 import { resolve } from 'path';
-import { getLanguageDisplayName, toBaseLanguageCode } from '@/lib/shared/language';
+import {
+  getLanguageDisplayName,
+  resolveReplicateKokoroLanguageCode,
+  toBaseLanguageCode,
+} from '@/lib/shared/language';
 
 export interface ServerTTSRequest {
   text: string;
@@ -434,7 +438,7 @@ async function fetchTTSBufferWithRetry(
   }
 }
 
-async function buildReplicateInput(request: ResolvedServerTTSRequest): Promise<Record<string, unknown>> {
+export async function buildReplicateInput(request: ResolvedServerTTSRequest): Promise<Record<string, unknown>> {
   const model = request.model as string;
 
   if (model === 'google/gemini-3.1-flash-tts') {
@@ -518,6 +522,16 @@ async function addReplicateLanguageInput(
   request: ResolvedServerTTSRequest,
 ): Promise<Record<string, unknown>> {
   if (!request.language) return input;
+  if (request.model === REPLICATE_KOKORO_82M_VERSIONED_MODEL) {
+    const languageCode = resolveReplicateKokoroLanguageCode({
+      language: request.language,
+      voice: request.voice,
+    });
+    if (languageCode) {
+      input.language_code = languageCode;
+    }
+    return input;
+  }
   const languageInput = await resolveReplicateLanguageInput({
     provider: 'replicate',
     model: request.model as string,

--- a/src/lib/server/tts/generate.ts
+++ b/src/lib/server/tts/generate.ts
@@ -521,7 +521,6 @@ async function addReplicateLanguageInput(
   input: Record<string, unknown>,
   request: ResolvedServerTTSRequest,
 ): Promise<Record<string, unknown>> {
-  if (!request.language) return input;
   if (request.model === REPLICATE_KOKORO_82M_VERSIONED_MODEL) {
     const languageCode = resolveReplicateKokoroLanguageCode({
       language: request.language,
@@ -532,6 +531,7 @@ async function addReplicateLanguageInput(
     }
     return input;
   }
+  if (!request.language) return input;
   const languageInput = await resolveReplicateLanguageInput({
     provider: 'replicate',
     model: request.model as string,

--- a/src/lib/server/tts/generate.ts
+++ b/src/lib/server/tts/generate.ts
@@ -641,6 +641,7 @@ async function runProviderRequest(
   const openai = new OpenAI({
     apiKey: request.apiKey,
     baseURL: request.baseUrl,
+    defaultHeaders: request.apiKey ? undefined : { Authorization: null },
     maxRetries: 0,
     timeout: upstreamSettings.ttsUpstreamTimeoutMs,
   });

--- a/src/lib/server/tts/segments-blobstore.ts
+++ b/src/lib/server/tts/segments-blobstore.ts
@@ -244,7 +244,12 @@ export async function deleteTtsSegmentPrefix(prefix: string): Promise<number> {
           },
         }),
       );
-      deleted += deleteRes.Deleted?.length ?? 0;
+      const errors = deleteRes.Errors ?? [];
+      if (errors.length > 0) {
+        throw new Error(`Failed deleting ${errors.length} TTS segment audio objects`);
+      }
+      // Quiet=true commonly omits Deleted entries on successful requests.
+      deleted += keys.length;
     }
 
     continuationToken = listRes.IsTruncated ? listRes.NextContinuationToken : undefined;

--- a/src/lib/server/tts/segments-cache.ts
+++ b/src/lib/server/tts/segments-cache.ts
@@ -1,7 +1,12 @@
 import { and, eq } from 'drizzle-orm';
 import { db } from '@/db';
 import { ttsSegmentEntries, ttsSegmentVariants } from '@/db/schema';
-import { deleteTtsSegmentAudioObjects } from '@/lib/server/tts/segments-blobstore';
+import {
+  deleteTtsSegmentAudioObjects,
+  deleteTtsSegmentPrefix,
+} from '@/lib/server/tts/segments-blobstore';
+import { buildTtsSegmentDocumentPrefix } from '@/lib/server/tts/segments';
+import { getS3Config } from '@/lib/server/storage/s3';
 import type { ReaderType } from '@/types/user-state';
 import { serverLogger } from '@/lib/server/logger';
 import { logDegraded } from '@/lib/server/errors/logging';
@@ -50,8 +55,6 @@ export async function clearTtsSegmentCache(
     )
     .where(and(...conditions))) as Array<{ segmentId: string; audioKey: string | null }>;
 
-  await db.delete(ttsSegmentEntries).where(and(...conditions));
-
   const audioKeys = rows
     .map((row) => row.audioKey)
     .filter((key): key is string => Boolean(key));
@@ -80,10 +83,38 @@ export async function clearTtsSegmentCache(
     }
   }
 
+  // Keep metadata when storage cleanup is incomplete so a later retry still
+  // knows which objects must be removed.
+  if (!warning) {
+    await db.delete(ttsSegmentEntries).where(and(...conditions));
+  }
+
   return {
-    deletedSegments: rows.length,
+    deletedSegments: warning ? 0 : rows.length,
     requestedAudioObjects: uniqueAudioKeys.length,
     deletedAudioObjects,
     ...(warning ? { warning } : {}),
   };
+}
+
+export async function deleteDocumentTtsSegmentCache(input: {
+  userId: string;
+  documentId: string;
+  namespace: string | null;
+}): Promise<void> {
+  const storagePrefix = getS3Config().prefix;
+  for (const storageVersion of ['v1', 'v2'] as const) {
+    await deleteTtsSegmentPrefix(buildTtsSegmentDocumentPrefix({
+      storagePrefix,
+      namespace: input.namespace,
+      userId: input.userId,
+      documentId: input.documentId,
+      storageVersion,
+    }));
+  }
+
+  await db.delete(ttsSegmentEntries).where(and(
+    eq(ttsSegmentEntries.userId, input.userId),
+    eq(ttsSegmentEntries.documentId, input.documentId),
+  ));
 }

--- a/src/lib/server/tts/segments.ts
+++ b/src/lib/server/tts/segments.ts
@@ -226,6 +226,17 @@ export function buildTtsSegmentAudioKey(input: {
   return `${input.storagePrefix}/tts_segments_v2/${nsSegment}users/${encodeURIComponent(input.userId)}/docs/${input.documentId}/${input.documentVersion}/${input.settingsHash}/${input.segmentId}.mp3`;
 }
 
+export function buildTtsSegmentDocumentPrefix(input: {
+  storagePrefix: string;
+  namespace: string | null;
+  userId: string;
+  documentId: string;
+  storageVersion?: 'v1' | 'v2';
+}): string {
+  const nsSegment = input.namespace ? `ns/${input.namespace}/` : '';
+  return `${input.storagePrefix}/tts_segments_${input.storageVersion ?? 'v2'}/${nsSegment}users/${encodeURIComponent(input.userId)}/docs/${input.documentId}/`;
+}
+
 export async function probeAudioDurationMsFromBuffer(buffer: Buffer, signal?: AbortSignal): Promise<number> {
   let workDir: string | null = null;
   try {

--- a/src/lib/server/tts/voice-resolution.ts
+++ b/src/lib/server/tts/voice-resolution.ts
@@ -311,7 +311,7 @@ export async function resolveReplicateLanguageInput({
   model,
   apiKey = '',
 }: ResolveVoicesOptions): Promise<ReplicateLanguageInput | null> {
-  if (provider !== 'replicate' || REPLICATE_BUILT_IN_MODELS.has(model) || !apiKey) return null;
+  if (provider !== 'replicate' || !apiKey) return null;
 
   const cached = replicateLanguageInputCache.get(model);
   if (cached) return cached;

--- a/src/lib/server/tts/voice-resolution.ts
+++ b/src/lib/server/tts/voice-resolution.ts
@@ -377,7 +377,7 @@ async function fetchCustomOpenAiVoices(baseUrl: string, apiKey: string): Promise
     const response = await fetch(`${normalizedBaseUrl}/audio/voices`, {
       signal: controller.signal,
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
         'Content-Type': 'application/json',
       },
     });

--- a/src/lib/server/user/data-cleanup.ts
+++ b/src/lib/server/user/data-cleanup.ts
@@ -5,10 +5,16 @@
  */
 
 import { db } from '@/db';
-import { documents, audiobooks } from '@/db/schema';
-import { eq } from 'drizzle-orm';
+import { documents, audiobooks, userJobEvents, userTtsChars } from '@/db/schema';
+import * as authSchemaSqlite from '@/db/schema_auth_sqlite';
+import * as authSchemaPostgres from '@/db/schema_auth_postgres';
+import { and, eq, ne } from 'drizzle-orm';
 import { getS3Config, isS3Configured } from '@/lib/server/storage/s3';
-import { deleteDocumentBlob } from '@/lib/server/documents/blobstore';
+import {
+  deleteDocumentBlob,
+  deleteDocumentPrefix,
+  tempDocumentUploadPrefix,
+} from '@/lib/server/documents/blobstore';
 import { deleteDocumentPreviewArtifacts } from '@/lib/server/documents/previews-blobstore';
 import { deleteDocumentPreviewRows } from '@/lib/server/documents/previews';
 import { audiobookPrefix, deleteAudiobookPrefix } from '@/lib/server/audiobooks/blobstore';
@@ -34,9 +40,11 @@ export async function deleteUserStorageData(
   namespace: string | null,
 ): Promise<void> {
   const s3Enabled = isS3Configured();
+  const failures: unknown[] = [];
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const database = db as any;
+  const authSchema = process.env.POSTGRES_URL ? authSchemaPostgres : authSchemaSqlite;
 
   // --- Documents & previews ---
   const userDocs: DocumentRow[] = await database
@@ -46,11 +54,22 @@ export async function deleteUserStorageData(
 
   let docsDeleted = 0;
   for (const doc of userDocs) {
-    if (s3Enabled) {
+    const otherOwners = await database
+      .select({ id: documents.id })
+      .from(documents)
+      .where(and(
+        eq(documents.id, doc.id),
+        ne(documents.userId, userId),
+      ))
+      .limit(1);
+    const isLastOwner = otherOwners.length === 0;
+
+    if (s3Enabled && isLastOwner) {
       try {
         await deleteDocumentBlob(doc.id, namespace);
         docsDeleted++;
       } catch (error) {
+        failures.push(error);
         logDegraded(serverLogger, {
           event: 'user.data_cleanup.document_blob_delete.failed',
           msg: 'Failed to delete document blob',
@@ -66,6 +85,7 @@ export async function deleteUserStorageData(
       try {
         await deleteDocumentPreviewArtifacts(doc.id, namespace);
       } catch (error) {
+        failures.push(error);
         logDegraded(serverLogger, {
           event: 'user.data_cleanup.document_preview_delete.failed',
           msg: 'Failed to delete preview artifacts',
@@ -79,20 +99,24 @@ export async function deleteUserStorageData(
       }
     }
 
-    // Always clean up DB rows — documentPreviews has no FK cascade on user.
-    try {
-      await deleteDocumentPreviewRows(doc.id, namespace);
-    } catch (error) {
-      logDegraded(serverLogger, {
-        event: 'user.data_cleanup.document_preview_rows_delete.failed',
-        msg: 'Failed to delete preview rows',
-        step: 'delete_document_preview_rows',
-        context: {
-          documentId: doc.id,
-          userIdHash: hashForLog(userId),
-        },
-        error,
-      });
+    // Preview rows/artifacts are shared by document id, so only the final
+    // owner may remove them.
+    if (isLastOwner) {
+      try {
+        await deleteDocumentPreviewRows(doc.id, namespace);
+      } catch (error) {
+        failures.push(error);
+        logDegraded(serverLogger, {
+          event: 'user.data_cleanup.document_preview_rows_delete.failed',
+          msg: 'Failed to delete preview rows',
+          step: 'delete_document_preview_rows',
+          context: {
+            documentId: doc.id,
+            userIdHash: hashForLog(userId),
+          },
+          error,
+        });
+      }
     }
   }
 
@@ -111,6 +135,7 @@ export async function deleteUserStorageData(
       await deleteAudiobookPrefix(prefix);
       booksDeleted++;
     } catch (error) {
+      failures.push(error);
       logDegraded(serverLogger, {
         event: 'user.data_cleanup.audiobook_blobs_delete.failed',
         msg: 'Failed to delete audiobook blobs',
@@ -128,6 +153,19 @@ export async function deleteUserStorageData(
   let segmentsDeleted = 0;
   if (s3Enabled) {
     try {
+      await deleteDocumentPrefix(tempDocumentUploadPrefix(userId, namespace));
+    } catch (error) {
+      failures.push(error);
+      logDegraded(serverLogger, {
+        event: 'user.data_cleanup.temp_document_uploads_delete.failed',
+        msg: 'Failed to delete temporary document uploads',
+        step: 'delete_temp_document_upload_prefix',
+        context: { userIdHash: hashForLog(userId) },
+        error,
+      });
+    }
+
+    try {
       const cfg = getS3Config();
       const nsSegment = namespace ? `ns/${namespace}/` : '';
       const ttsPrefixV1 = `${cfg.prefix}/tts_segments_v1/${nsSegment}users/${encodeURIComponent(userId)}/`;
@@ -135,12 +173,41 @@ export async function deleteUserStorageData(
       segmentsDeleted += await deleteTtsSegmentPrefix(ttsPrefixV1);
       segmentsDeleted += await deleteTtsSegmentPrefix(ttsPrefixV2);
     } catch (error) {
+      failures.push(error);
       logDegraded(serverLogger, {
         event: 'user.data_cleanup.tts_segments_delete.failed',
         msg: 'Failed to delete TTS segment blobs',
         step: 'delete_tts_segment_prefixes',
         context: { userIdHash: hashForLog(userId) },
         error,
+      });
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `User storage cleanup failed in ${failures.length} operation(s)`);
+  }
+
+  // Namespaced cleanup is an additional storage pass made by the account
+  // route. Database rows are global and must only be removed during the
+  // canonical non-namespaced beforeDelete pass.
+  if (namespace === null) {
+    // Delete explicitly for compatibility with pre-cascade installations and
+    // to remove auth verification tokens, which cannot carry a user FK.
+    for (const { table, userColumn, step } of [
+      { table: userTtsChars, userColumn: userTtsChars.userId, step: 'delete_user_tts_usage_rows' },
+      { table: userJobEvents, userColumn: userJobEvents.userId, step: 'delete_user_job_event_rows' },
+      { table: authSchema.verification, userColumn: authSchema.verification.value, step: 'delete_user_verification_rows' },
+    ]) {
+      await database.delete(table).where(eq(userColumn, userId)).catch((error: unknown) => {
+        failures.push(error);
+        logDegraded(serverLogger, {
+          event: 'user.data_cleanup.db_rows_delete.failed',
+          msg: 'Failed to delete non-cascading user database rows',
+          step,
+          context: { userIdHash: hashForLog(userId) },
+          error,
+        });
       });
     }
   }
@@ -155,5 +222,9 @@ export async function deleteUserStorageData(
       totalBooks: userBooks.length,
       segmentsDeleted,
     }, 'Completed user storage cleanup');
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `User database cleanup failed in ${failures.length} operation(s)`);
   }
 }

--- a/src/lib/server/user/data-export.ts
+++ b/src/lib/server/user/data-export.ts
@@ -11,7 +11,7 @@ export type ExportBlobBody =
   | ArrayBufferView
   | { transformToByteArray: () => Promise<Uint8Array> };
 
-type ExportIssueScope = 'document' | 'audiobook' | 'audiobook_list';
+type ExportIssueScope = 'document' | 'audiobook' | 'audiobook_list' | 'tts_segment';
 
 type ExportIssue = {
   scope: ExportIssueScope;
@@ -41,6 +41,20 @@ type ExportAudiobookObject = {
   [key: string]: unknown;
 };
 
+type ExportTtsSegmentEntry = {
+  segmentEntryId: string;
+  documentId: string;
+  [key: string]: unknown;
+};
+
+type ExportTtsSegmentVariant = {
+  segmentId: string;
+  segmentEntryId: string;
+  audioKey?: string | null;
+  audioFormat?: string | null;
+  [key: string]: unknown;
+};
+
 export type AppendUserExportArchiveInput = {
   archive: Archiver;
   userId: string;
@@ -49,12 +63,19 @@ export type AppendUserExportArchiveInput = {
   preferences: unknown | null;
   readingHistory: unknown[];
   ttsUsage: unknown[];
+  jobEvents: unknown[];
+  documentSettings: unknown[];
+  authSessions: unknown[];
+  linkedAccounts: unknown[];
   documents: ExportDocument[];
   audiobooks: ExportAudiobook[];
   audiobookChapters: ExportAudiobookChapter[];
+  ttsSegmentEntries: ExportTtsSegmentEntry[];
+  ttsSegmentVariants: ExportTtsSegmentVariant[];
   getDocumentBlobStream: (documentId: string) => Promise<ExportBlobBody>;
   listAudiobookObjects: (bookId: string, userId: string) => Promise<ExportAudiobookObject[]>;
   getAudiobookObjectStream: (bookId: string, userId: string, fileName: string) => Promise<ExportBlobBody>;
+  getTtsSegmentAudioStream: (audioKey: string) => Promise<ExportBlobBody>;
 };
 
 function isNodeReadableStream(value: unknown): value is Readable {
@@ -124,17 +145,25 @@ export async function appendUserExportArchive(input: AppendUserExportArchiveInpu
     preferences,
     readingHistory,
     ttsUsage,
+    jobEvents,
+    documentSettings,
+    authSessions,
+    linkedAccounts,
     documents,
     audiobooks,
     audiobookChapters,
+    ttsSegmentEntries,
+    ttsSegmentVariants,
     getDocumentBlobStream,
     listAudiobookObjects,
     getAudiobookObjectStream,
+    getTtsSegmentAudioStream,
   } = input;
 
   const issues: ExportIssue[] = [];
   let documentFilesExported = 0;
   let audiobookFilesExported = 0;
+  let ttsSegmentFilesExported = 0;
 
   appendJson(archive, 'profile.json', profileData);
   if (preferences) {
@@ -142,7 +171,13 @@ export async function appendUserExportArchive(input: AppendUserExportArchiveInpu
   }
   appendJson(archive, 'reading_history.json', readingHistory);
   appendJson(archive, 'tts_usage.json', ttsUsage);
+  appendJson(archive, 'job_events.json', jobEvents);
+  appendJson(archive, 'document_settings.json', documentSettings);
+  appendJson(archive, 'auth_sessions.json', authSessions);
+  appendJson(archive, 'linked_accounts.json', linkedAccounts);
   appendJson(archive, 'library_documents.json', documents);
+  appendJson(archive, 'tts_segment_entries.json', ttsSegmentEntries);
+  appendJson(archive, 'tts_segment_variants.json', ttsSegmentVariants);
 
   const chaptersByBookId = new Map<string, ExportAudiobookChapter[]>();
   for (const chapter of audiobookChapters) {
@@ -215,8 +250,40 @@ export async function appendUserExportArchive(input: AppendUserExportArchiveInpu
     }
   }
 
+  const documentIdByEntryId = new Map(
+    ttsSegmentEntries.map((entry) => [entry.segmentEntryId, entry.documentId]),
+  );
+  const exportedAudioKeys = new Set<string>();
+  for (const variant of ttsSegmentVariants) {
+    const audioKey = typeof variant.audioKey === 'string' ? variant.audioKey : '';
+    if (!audioKey || exportedAudioKeys.has(audioKey)) continue;
+    exportedAudioKeys.add(audioKey);
+
+    const documentId = toSafePathSegment(
+      documentIdByEntryId.get(variant.segmentEntryId) ?? 'unknown-document',
+      'unknown-document',
+    );
+    const segmentId = toSafePathSegment(variant.segmentId, 'segment');
+    const format = toSafePathSegment(variant.audioFormat || 'mp3', 'mp3');
+    const entryName = `files/tts_segments/${documentId}/${segmentId}.${format}`;
+
+    try {
+      const body = await getTtsSegmentAudioStream(audioKey);
+      const stream = await bodyToNodeReadable(body);
+      archive.append(stream, { name: entryName });
+      ttsSegmentFilesExported += 1;
+    } catch (error) {
+      issues.push({
+        scope: 'tts_segment',
+        id: variant.segmentId,
+        fileName: entryName,
+        message: normalizeErrorMessage(error),
+      });
+    }
+  }
+
   const manifest = {
-    formatVersion: 2,
+    formatVersion: 3,
     exportedAtMs,
     userId,
     scope: 'owned',
@@ -224,14 +291,26 @@ export async function appendUserExportArchive(input: AppendUserExportArchiveInpu
       documentsMetadata: documents.length,
       audiobooksMetadata: audiobooks.length,
       audiobookChaptersMetadata: audiobookChapters.length,
+      documentSettingsMetadata: documentSettings.length,
+      ttsSegmentEntriesMetadata: ttsSegmentEntries.length,
+      ttsSegmentVariantsMetadata: ttsSegmentVariants.length,
+      authSessionsMetadata: authSessions.length,
+      linkedAccountsMetadata: linkedAccounts.length,
+      jobEventsMetadata: jobEvents.length,
       documentFiles: documentFilesExported,
       audiobookFiles: audiobookFilesExported,
+      ttsSegmentFiles: ttsSegmentFilesExported,
       issues: issues.length,
     },
     includes: {
       metadata: true,
       documentFiles: true,
       audiobookFiles: true,
+      ttsSegmentFiles: true,
+      credentialSecrets: false,
+      temporaryUploads: false,
+      derivedDocumentPreviews: false,
+      derivedParsedDocuments: false,
       filesystemSources: false,
     },
   };

--- a/src/lib/server/user/preferences-normalize.ts
+++ b/src/lib/server/user/preferences-normalize.ts
@@ -1,0 +1,161 @@
+import { SYNCED_PREFERENCE_KEYS, type SyncedPreferencesPatch } from '@/types/user-state';
+import { isBuiltInTtsProviderId, isTtsProviderType, type TtsProviderId } from '@/lib/shared/tts-provider-catalog';
+import { resolveProviderDefaults } from '@/lib/shared/tts-provider-policy';
+
+export interface PreferenceNormalizationContext {
+  showAllProviderModels: boolean;
+  restrictUserApiKeys: boolean;
+  sharedProviders: Array<{
+    slug: string;
+    providerType: TtsProviderId;
+    defaultModel: string | null;
+    defaultInstructions: string | null;
+  }>;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function sanitizeSavedVoices(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (typeof key !== 'string' || key.length === 0) continue;
+    if (typeof val !== 'string') continue;
+    out[key] = val;
+  }
+  return out;
+}
+
+/**
+ * Normalize a stored/incoming preferences blob into a clean synced-preferences
+ * patch.
+ *
+ * Provider handling follows an "inherit the admin default" model: an empty
+ * `providerRef` means the user has made no explicit choice and should follow the
+ * instance default. We deliberately preserve empty rather than collapsing it to
+ * a concrete provider, so inheriting users track whatever the admin configures.
+ * Built-in provider ids under restricted mode (and the legacy `default-openai`
+ * sentinel that isn't a real shared provider) are mapped back to inherit.
+ */
+export function sanitizePreferencesPatch(
+  input: unknown,
+  context: PreferenceNormalizationContext,
+  options: { fillMissingProvider: boolean },
+): { patch: SyncedPreferencesPatch; migrated: boolean } {
+  if (!isRecord(input)) return { patch: {}, migrated: false };
+
+  const rec = input as Record<string, unknown>;
+  const out: SyncedPreferencesPatch = {};
+  let migrated = false;
+
+  const legacyProviderRef = typeof rec.ttsProvider === 'string'
+    ? rec.ttsProvider
+    : typeof rec.provider === 'string'
+      ? rec.provider
+      : '';
+  const hasLegacyProviderKey = typeof rec.ttsProvider === 'string' || typeof rec.provider === 'string';
+  const hasProviderRefKey = typeof rec.providerRef === 'string';
+  const rawProviderRef = hasProviderRefKey ? (rec.providerRef as string) : legacyProviderRef;
+
+  const sharedSlugs = new Set(context.sharedProviders.map((entry) => entry.slug));
+  let providerRefIntent = typeof rawProviderRef === 'string' ? rawProviderRef.trim() : '';
+  // Legacy 'default-openai' sentinel: only honored when it's a real configured
+  // shared provider; otherwise it historically meant "use the default" → inherit.
+  if (providerRefIntent === 'default-openai' && !sharedSlugs.has('default-openai')) {
+    providerRefIntent = '';
+  }
+  // Built-in providers aren't selectable under restricted mode → inherit. This
+  // also migrates the old baked-in 'custom-openai' default off existing rows.
+  if (context.restrictUserApiKeys && isBuiltInTtsProviderId(providerRefIntent)) {
+    providerRefIntent = '';
+  }
+  const providerRefIsExplicit = providerRefIntent.length > 0;
+  const providerDefaults = providerRefIsExplicit
+    ? resolveProviderDefaults({
+      providerRef: providerRefIntent,
+      providerType: isTtsProviderType(rec.providerType) ? rec.providerType : 'unknown',
+      sharedProviders: context.sharedProviders,
+    })
+    : null;
+
+  if (hasLegacyProviderKey || (hasProviderRefKey && (rec.providerRef as string) !== providerRefIntent)) {
+    migrated = true;
+  }
+
+  for (const key of SYNCED_PREFERENCE_KEYS) {
+    if (!(key in rec)) continue;
+    const value = rec[key];
+
+    switch (key) {
+      case 'viewType':
+        if (value === 'single' || value === 'dual' || value === 'scroll') out[key] = value;
+        break;
+      case 'voice':
+      case 'ttsInstructions':
+        if (typeof value === 'string') out[key] = value;
+        break;
+      // providerRef / providerType / ttsModel are resolved together below.
+      case 'providerRef':
+      case 'providerType':
+      case 'ttsModel':
+        break;
+      case 'voiceSpeed':
+      case 'audioPlayerSpeed':
+      case 'segmentPreloadDepthPages':
+      case 'segmentPreloadSentenceLookahead':
+      case 'ttsSegmentMaxBlockLength':
+      case 'headerMargin':
+      case 'footerMargin':
+      case 'leftMargin':
+      case 'rightMargin':
+        if (Number.isFinite(value)) out[key] = Number(value);
+        break;
+      case 'skipBlank':
+      case 'epubTheme':
+      case 'pdfHighlightEnabled':
+      case 'pdfWordHighlightEnabled':
+      case 'epubHighlightEnabled':
+      case 'epubWordHighlightEnabled':
+      case 'htmlHighlightEnabled':
+      case 'htmlWordHighlightEnabled':
+        if (typeof value === 'boolean') out[key] = value;
+        break;
+      case 'savedVoices':
+        out[key] = sanitizeSavedVoices(value);
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Persist concrete provider/type/model only for an explicit selection. An
+  // inheriting user keeps these empty so resolution happens against the live
+  // admin default at read/generation time.
+  const shouldWriteProvider = hasProviderRefKey || hasLegacyProviderKey || options.fillMissingProvider;
+  if (shouldWriteProvider) {
+    out.providerRef = providerRefIntent;
+    out.providerType = providerRefIsExplicit ? providerDefaults!.providerType : 'unknown';
+  }
+
+  if (providerRefIsExplicit) {
+    const rawModel = typeof rec.ttsModel === 'string' ? rec.ttsModel.trim() : '';
+    const lockedToDefault = !context.showAllProviderModels && !!providerDefaults!.defaultModel;
+    const model = lockedToDefault
+      ? providerDefaults!.defaultModel
+      : (rawModel || providerDefaults!.defaultModel);
+    if (model) {
+      out.ttsModel = model;
+      if (model !== rawModel) migrated = true;
+    } else if (typeof rec.ttsModel === 'string') {
+      out.ttsModel = rec.ttsModel;
+    }
+  } else if (shouldWriteProvider || 'ttsModel' in rec) {
+    // Inheriting: the model inherits too.
+    if (typeof rec.ttsModel === 'string' && rec.ttsModel !== '') migrated = true;
+    out.ttsModel = '';
+  }
+
+  return { patch: out, migrated };
+}

--- a/src/lib/server/user/preferences-normalize.ts
+++ b/src/lib/server/user/preferences-normalize.ts
@@ -14,7 +14,7 @@ export interface PreferenceNormalizationContext {
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 export function sanitizeSavedVoices(value: unknown): Record<string, string> {

--- a/src/lib/shared/language.ts
+++ b/src/lib/shared/language.ts
@@ -28,6 +28,28 @@ const KOKORO_LANGUAGE_BY_PREFIX: Readonly<Record<string, string>> = {
   zm: 'zh-CN',
 };
 
+const REPLICATE_KOKORO_LANGUAGE_CODE_BY_TAG: Readonly<Record<string, string>> = {
+  'en-US': 'a',
+  'en-GB': 'b',
+  es: 'e',
+  fr: 'f',
+  hi: 'h',
+  it: 'i',
+  ja: 'j',
+  'pt-BR': 'p',
+  'zh-CN': 'z',
+};
+
+const REPLICATE_KOKORO_LANGUAGE_CODE_BY_BASE_TAG: Readonly<Record<string, string>> = {
+  es: 'e',
+  fr: 'f',
+  hi: 'h',
+  it: 'i',
+  ja: 'j',
+  pt: 'p',
+  zh: 'z',
+};
+
 export const KOKORO_SUPPORTED_LANGUAGES = [
   'en',
   'es',
@@ -77,6 +99,26 @@ export function inferKokoroLanguageFromVoice(voice: string | null | undefined): 
   const languages = new Set(getKokoroVoiceLanguages(voice));
 
   return languages.size === 1 ? [...languages][0] : null;
+}
+
+export function resolveReplicateKokoroLanguageCode(input: {
+  language?: string | null;
+  voice?: string | null;
+}): string | null {
+  const normalizedLanguage = input.language ? normalizeLanguageTag(input.language) : null;
+  const voiceLanguage = inferKokoroLanguageFromVoice(input.voice);
+
+  for (const candidate of [normalizedLanguage, voiceLanguage]) {
+    if (!candidate) continue;
+
+    const exactCode = REPLICATE_KOKORO_LANGUAGE_CODE_BY_TAG[candidate];
+    if (exactCode) return exactCode;
+
+    const baseCode = REPLICATE_KOKORO_LANGUAGE_CODE_BY_BASE_TAG[toBaseLanguageCode(candidate)];
+    if (baseCode) return baseCode;
+  }
+
+  return null;
 }
 
 export function getKokoroVoiceLanguages(voice: string | null | undefined): string[] {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,21 +1,5 @@
 import type { DocumentListState } from '@/types/documents';
-import { isBuiltInTtsProviderId, type TtsProviderType } from '@/lib/shared/tts-provider-catalog';
-import { defaultModelForProviderType } from '@/lib/shared/tts-provider-policy';
-
-// Runtime config (admin-controlled) is layered on top of the static defaults
-// below. We resolve it lazily so this module stays importable from non-React
-// contexts (Dexie, server routes). The actual values come from
-// `window.__RUNTIME_CONFIG__` (SSR-injected) on the client, and
-// from the built-in defaults during SSR.
-
-function readRuntimeString(key: string, defaultValue: string): string {
-  if (typeof window === 'undefined') return defaultValue;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const injected = (window as any).__RUNTIME_CONFIG__;
-  if (!injected || typeof injected !== 'object') return defaultValue;
-  const value = injected[key];
-  return typeof value === 'string' && value ? value : defaultValue;
-}
+import type { TtsProviderType } from '@/lib/shared/tts-provider-catalog';
 
 export type ViewType = 'single' | 'dual' | 'scroll';
 
@@ -78,20 +62,18 @@ export interface AppConfigValues {
 }
 
 /**
- * Build defaults lazily so we can read SSR-injected admin overrides
- * (`window.__RUNTIME_CONFIG__`). Modules that need the defaults
- * statically should call `getAppConfigDefaults()` at use time. The exported
- * `APP_CONFIG_DEFAULTS` is a Proxy that re-resolves on each access so
- * mutations to the runtime config (admin edits) are picked up by anything
- * that reads through it.
+ * Build the static app-config defaults. These no longer read any SSR/admin
+ * runtime config: the user's TTS provider defaults to empty ("inherit the
+ * admin default"), which is resolved to a concrete provider where it is used
+ * (ConfigContext on the client, credential resolution on the server).
  */
 export function getAppConfigDefaults(): AppConfigValues {
-  const runtimeProviderRef = readRuntimeString('defaultTtsProvider', 'custom-openai');
-  const defaultProviderRef = runtimeProviderRef.trim();
-  const defaultProviderType = isBuiltInTtsProviderId(defaultProviderRef) ? defaultProviderRef : 'unknown';
-  const defaultModel = isBuiltInTtsProviderId(defaultProviderType)
-    ? defaultModelForProviderType(defaultProviderType)
-    : 'kokoro';
+  // The user's TTS provider is intentionally left empty by default. An empty
+  // providerRef means "inherit the instance/admin default" and is resolved to a
+  // concrete provider at read time (see ConfigContext) and at generation time
+  // (server-side credential resolution). We no longer bake a placeholder
+  // provider id (the old 'custom-openai') into every user's config, since that
+  // value isn't actually selectable in shared-provider mode.
   return {
     apiKey: '',
     baseUrl: '',
@@ -105,9 +87,9 @@ export function getAppConfigDefaults(): AppConfigValues {
     footerMargin: 0,
     leftMargin: 0,
     rightMargin: 0,
-    providerRef: defaultProviderRef,
-    providerType: defaultProviderType,
-    ttsModel: defaultModel,
+    providerRef: '',
+    providerType: 'unknown',
+    ttsModel: '',
     ttsInstructions: '',
     savedVoices: {},
     segmentPreloadDepthPages: 1,
@@ -134,17 +116,13 @@ export function getAppConfigDefaults(): AppConfigValues {
 }
 
 /**
- * Static defaults snapshot resolved at first access. For callers that need
- * fresh values after admin edits, prefer `getAppConfigDefaults()` directly.
- * Most consumers just need a stable defaults object for spreads, so this is
- * resolved once per process — admin overrides take effect on next page load
- * (which is the SSR-injected behavior we want anyway).
+ * Static defaults snapshot, resolved once at first access. The values are
+ * constant (no SSR/admin overrides are read here anymore), so the lazy Proxy
+ * just avoids building the object until something first reads it.
  */
 let cachedDefaults: AppConfigValues | null = null;
 export const APP_CONFIG_DEFAULTS: AppConfigValues = (() => {
-  // Return a getter-backed object that resolves on first access. On the
-  // server, this resolves to built-in defaults; on the client, to the
-  // SSR-injected admin values.
+  // Getter-backed object that builds the defaults lazily on first access.
   const handler: ProxyHandler<AppConfigValues> = {
     get(_target, prop) {
       if (!cachedDefaults) cachedDefaults = getAppConfigDefaults();

--- a/tests/unit/admin-providers-validation.vitest.spec.ts
+++ b/tests/unit/admin-providers-validation.vitest.spec.ts
@@ -5,6 +5,8 @@ import { adminProviders } from '../../src/db/schema';
 
 import {
   AdminProviderError,
+  createAdminProvider,
+  decryptedKeyFor,
   listAdminProviders,
   toMasked,
   validateProviderType,
@@ -51,6 +53,23 @@ describe('admin provider validation', () => {
     };
 
     expect(toMasked(record).apiKeyMask).toBe('••••abcd');
+  });
+
+  test('creates providers without an API key', async () => {
+    const suffix = `${Date.now()}${Math.random().toString(36).slice(2, 8)}`;
+    const created = await createAdminProvider({
+      slug: `keyless-${suffix}`,
+      displayName: 'Keyless Provider',
+      providerType: 'custom-openai',
+      baseUrl: 'http://localhost:8880/v1',
+    });
+
+    try {
+      expect(toMasked(created).apiKeyMask).toBe('(not set)');
+      await expect(decryptedKeyFor(created)).resolves.toBe('');
+    } finally {
+      await db.delete(adminProviders).where(inArray(adminProviders.id, [created.id]));
+    }
   });
 
   test('lists providers in deterministic updated/created/slug order', async () => {

--- a/tests/unit/data-export.vitest.spec.ts
+++ b/tests/unit/data-export.vitest.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+import type { Archiver } from 'archiver';
+import { appendUserExportArchive } from '../../src/lib/server/user/data-export';
+
+describe('user data export archive', () => {
+  test('includes user metadata and cached TTS audio without credential secrets', async () => {
+    const entries = new Map<string, unknown>();
+    const archive = {
+      append(value: unknown, options: { name: string }) {
+        entries.set(options.name, value);
+        return archive;
+      },
+    } as unknown as Archiver;
+
+    await appendUserExportArchive({
+      archive,
+      userId: 'user-1',
+      exportedAtMs: 123,
+      profileData: { user: { id: 'user-1', email: 'person@example.com' }, exportedAtMs: 123 },
+      preferences: { dataJson: '{}' },
+      readingHistory: [{ documentId: 'doc-1' }],
+      ttsUsage: [{ charCount: 10 }],
+      jobEvents: [{ action: 'pdf-layout' }],
+      documentSettings: [{ documentId: 'doc-1', dataJson: '{}' }],
+      authSessions: [{ id: 'session-1', ipAddress: null }],
+      linkedAccounts: [{ id: 'account-1', providerId: 'credential' }],
+      documents: [],
+      audiobooks: [],
+      audiobookChapters: [],
+      ttsSegmentEntries: [{ segmentEntryId: 'entry-1', documentId: 'doc-1' }],
+      ttsSegmentVariants: [{
+        segmentId: 'segment-1',
+        segmentEntryId: 'entry-1',
+        audioKey: 'private/audio/key',
+        audioFormat: 'mp3',
+      }],
+      getDocumentBlobStream: async () => new Uint8Array(),
+      listAudiobookObjects: async () => [],
+      getAudiobookObjectStream: async () => new Uint8Array(),
+      getTtsSegmentAudioStream: async () => new Uint8Array([1, 2, 3]),
+    });
+
+    expect(entries.has('document_settings.json')).toBe(true);
+    expect(entries.has('auth_sessions.json')).toBe(true);
+    expect(entries.has('linked_accounts.json')).toBe(true);
+    expect(entries.has('tts_segment_entries.json')).toBe(true);
+    expect(entries.has('tts_segment_variants.json')).toBe(true);
+    expect(entries.has('files/tts_segments/doc-1/segment-1.mp3')).toBe(true);
+
+    const manifest = JSON.parse(String(entries.get('export_manifest.json')));
+    expect(manifest).toMatchObject({
+      formatVersion: 3,
+      counts: {
+        ttsSegmentEntriesMetadata: 1,
+        ttsSegmentVariantsMetadata: 1,
+        ttsSegmentFiles: 1,
+      },
+      includes: {
+        credentialSecrets: false,
+      },
+    });
+  });
+});

--- a/tests/unit/language.vitest.spec.ts
+++ b/tests/unit/language.vitest.spec.ts
@@ -8,6 +8,7 @@ import {
   keepKokoroVoicesInOneLanguage,
   normalizeOptionalLanguageTag,
   normalizeUnicodeToken,
+  resolveReplicateKokoroLanguageCode,
   resolveTtsLanguage,
   segmentSentences,
   segmentWords,
@@ -93,6 +94,13 @@ describe('multilingual language utilities', () => {
     expect(resolveTtsLanguage({ configuredLanguage: 'pt-BR', voice: 'jf_alpha' })).toBe('pt-BR');
     expect(resolveTtsLanguage({ configuredLanguage: 'auto', voice: 'jf_alpha' })).toBe('ja');
     expect(toBaseLanguageCode('zh-CN')).toBe('zh');
+  });
+
+  test('maps Kokoro voices and normalized language tags to Replicate language codes', () => {
+    expect(resolveReplicateKokoroLanguageCode({ language: 'en', voice: 'af_sarah' })).toBe('a');
+    expect(resolveReplicateKokoroLanguageCode({ language: 'en', voice: 'bf_emma' })).toBe('b');
+    expect(resolveReplicateKokoroLanguageCode({ language: 'ja-JP', voice: 'jf_alpha' })).toBe('j');
+    expect(resolveReplicateKokoroLanguageCode({ language: 'zh-TW', voice: 'zf_xiaobei' })).toBe('z');
   });
 
   test('normalizes Unicode tokens without dropping non-Latin scripts', () => {

--- a/tests/unit/runtime-seed-json.vitest.spec.ts
+++ b/tests/unit/runtime-seed-json.vitest.spec.ts
@@ -160,6 +160,26 @@ describe('runtime seed JSON parsing', () => {
     expect(__seedInternals.shouldUseEnvProviderFallback(false)).toBe(true);
     expect(__seedInternals.shouldUseEnvProviderFallback(true)).toBe(false);
   });
+
+  test('accepts seeded providers without an API key', () => {
+    const parsed = __seedInternals.parseRuntimeSeedDocument(JSON.stringify({
+      version: 1,
+      providers: [{
+        slug: 'keyless-provider',
+        displayName: 'Keyless Provider',
+        providerType: 'custom-openai',
+        baseUrl: 'http://localhost:8880/v1',
+      }],
+    }));
+
+    expect(parsed.seed.providers?.[0]).toMatchObject({
+      slug: 'keyless-provider',
+      displayName: 'Keyless Provider',
+      providerType: 'custom-openai',
+      baseUrl: 'http://localhost:8880/v1',
+    });
+    expect(parsed.seed.providers?.[0]).not.toHaveProperty('apiKey');
+  });
 });
 
 describe('runtime config JSON seeding', () => {
@@ -374,6 +394,44 @@ describe('provider seeding and fallback precedence', () => {
         baseUrl: 'http://localhost:8880/v1',
         defaultModel: 'kokoro',
         apiKeyLast4: '9876',
+      });
+    } finally {
+      await restoreProvidersBySlug(testSlugs, providerSnapshot);
+    }
+  });
+
+  test('falls back to API_BASE with a blank API_KEY', async () => {
+    const providerSnapshot = await snapshotProvidersBySlug(testSlugs);
+    const runtimeSeed = JSON.stringify({ version: 1, runtimeConfig: { enableUserSignups: true } });
+
+    try {
+      await db.delete(adminProviders).where(inArray(adminProviders.slug, testSlugs));
+      const blockedByOtherRows = await hasNonTestProviderRows(testSlugs);
+      if (blockedByOtherRows) return;
+
+      await withEnv({
+        RUNTIME_SEED_JSON: runtimeSeed,
+        RUNTIME_SEED_JSON_PATH: undefined,
+        API_BASE: 'http://localhost:8880/v1',
+        API_KEY: '',
+        AUTH_SECRET: 'seed-test-auth-secret-keyless',
+      }, async () => {
+        await __seedInternals.runSeed();
+      });
+
+      const rows = await db
+        .select({
+          slug: adminProviders.slug,
+          baseUrl: adminProviders.baseUrl,
+          apiKeyLast4: adminProviders.apiKeyLast4,
+        })
+        .from(adminProviders);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        slug: 'default-openai',
+        baseUrl: 'http://localhost:8880/v1',
+        apiKeyLast4: '',
       });
     } finally {
       await restoreProvidersBySlug(testSlugs, providerSnapshot);

--- a/tests/unit/storage-prefix-cleanup.vitest.spec.ts
+++ b/tests/unit/storage-prefix-cleanup.vitest.spec.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+}));
+
+vi.mock('@/lib/server/storage/s3', () => ({
+  getS3Config: () => ({ bucket: 'test-bucket', prefix: 'openreader-test' }),
+  getS3Client: () => ({ send: mocks.send }),
+  getS3ProxyClient: () => ({ send: mocks.send }),
+}));
+
+import { deleteAudiobookPrefix } from '../../src/lib/server/audiobooks/blobstore';
+import { deleteDocumentPrefix } from '../../src/lib/server/documents/blobstore';
+
+describe('storage prefix cleanup', () => {
+  beforeEach(() => {
+    mocks.send.mockReset();
+  });
+
+  test.each([
+    ['document', deleteDocumentPrefix],
+    ['audiobook', deleteAudiobookPrefix],
+  ])('%s cleanup counts successful quiet deletes', async (_name, removePrefix) => {
+    mocks.send
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'prefix/a' }, { Key: 'prefix/b' }],
+        IsTruncated: false,
+      })
+      .mockResolvedValueOnce({});
+
+    await expect(removePrefix('prefix/')).resolves.toBe(2);
+  });
+
+  test.each([
+    ['document', deleteDocumentPrefix],
+    ['audiobook', deleteAudiobookPrefix],
+  ])('%s cleanup fails on per-object storage errors', async (_name, removePrefix) => {
+    mocks.send
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'prefix/a' }],
+        IsTruncated: false,
+      })
+      .mockResolvedValueOnce({
+        Errors: [{ Key: 'prefix/a', Code: 'AccessDenied' }],
+      });
+
+    await expect(removePrefix('prefix/')).rejects.toThrow('Failed deleting 1');
+  });
+});

--- a/tests/unit/tts-generate.vitest.spec.ts
+++ b/tests/unit/tts-generate.vitest.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  buildReplicateInput,
   buildTTSCacheKey,
   extractReplicateAudioUrl,
   resolveReplicateLanguageValue,
 } from '../../src/lib/server/tts/generate';
+import { REPLICATE_KOKORO_82M_VERSIONED_MODEL } from '../../src/lib/shared/tts-provider-catalog';
 
 describe('replicate output URL extraction', () => {
   test('returns direct URL string output', () => {
@@ -69,5 +71,39 @@ describe('Replicate language schema values', () => {
     expect(resolveReplicateLanguageValue('ja-JP', ['en', 'ja', 'zh'])).toBe('ja');
     expect(resolveReplicateLanguageValue('ja-JP', ['English', 'Japanese'])).toBe('Japanese');
     expect(resolveReplicateLanguageValue('ja-JP', ['English', 'French'])).toBeNull();
+  });
+
+  test('includes language_code for the built-in Replicate Kokoro model', async () => {
+    await expect(buildReplicateInput({
+      text: 'Hello world',
+      voice: 'af_sarah',
+      speed: 1,
+      format: 'mp3',
+      model: REPLICATE_KOKORO_82M_VERSIONED_MODEL,
+      language: 'en',
+      provider: 'replicate',
+      apiKey: 'r8_token',
+      testNamespace: null,
+    })).resolves.toEqual({
+      text: 'Hello world',
+      voice: 'af_sarah',
+      language_code: 'a',
+    });
+
+    await expect(buildReplicateInput({
+      text: 'Hello world',
+      voice: 'bf_emma',
+      speed: 1,
+      format: 'mp3',
+      model: REPLICATE_KOKORO_82M_VERSIONED_MODEL,
+      language: 'en',
+      provider: 'replicate',
+      apiKey: 'r8_token',
+      testNamespace: null,
+    })).resolves.toEqual({
+      text: 'Hello world',
+      voice: 'bf_emma',
+      language_code: 'b',
+    });
   });
 });

--- a/tests/unit/tts-generate.vitest.spec.ts
+++ b/tests/unit/tts-generate.vitest.spec.ts
@@ -105,5 +105,20 @@ describe('Replicate language schema values', () => {
       voice: 'bf_emma',
       language_code: 'b',
     });
+
+    await expect(buildReplicateInput({
+      text: 'Hello world',
+      voice: 'af_sarah',
+      speed: 1,
+      format: 'mp3',
+      model: REPLICATE_KOKORO_82M_VERSIONED_MODEL,
+      provider: 'replicate',
+      apiKey: 'r8_token',
+      testNamespace: null,
+    })).resolves.toEqual({
+      text: 'Hello world',
+      voice: 'af_sarah',
+      language_code: 'a',
+    });
   });
 });

--- a/tests/unit/tts-provider-catalog.vitest.spec.ts
+++ b/tests/unit/tts-provider-catalog.vitest.spec.ts
@@ -476,9 +476,13 @@ describe('config helpers', () => {
       ttsModel: 'kokoro',
     });
 
+    // The user's provider/model now default to empty ("inherit the admin
+    // default"), so empty values are treated as defaults and filtered out.
     expect(buildSyncedPreferencePatch({
       voiceSpeed: 1,
-      ttsModel: 'kokoro',
+      providerRef: '',
+      providerType: 'unknown',
+      ttsModel: '',
     }, { nonDefaultOnly: true })).toEqual({});
   });
 });

--- a/tests/unit/tts-provider-catalog.vitest.spec.ts
+++ b/tests/unit/tts-provider-catalog.vitest.spec.ts
@@ -435,6 +435,50 @@ describe('tts provider catalog', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test('discovers Replicate language input key for built-in models too', async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          latest_version: {
+            openapi_schema: {
+              components: {
+                schemas: {
+                  Input: {
+                    type: 'object',
+                    properties: {
+                      text: { type: 'string' },
+                      language: { type: 'string', enum: ['auto', 'en', 'ja'] },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      } as Response;
+    };
+
+    try {
+      await expect(resolveReplicateLanguageInputKey({
+        provider: 'replicate',
+        model: 'minimax/speech-2.8-turbo',
+        apiKey: 'r8_token',
+      })).resolves.toBe('language');
+      await expect(resolveReplicateLanguageInputKey({
+        provider: 'replicate',
+        model: 'minimax/speech-2.8-turbo',
+        apiKey: 'r8_token',
+      })).resolves.toBe('language');
+      expect(calls).toBe(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe('config helpers', () => {

--- a/tests/unit/tts-segments-blobstore.vitest.spec.ts
+++ b/tests/unit/tts-segments-blobstore.vitest.spec.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+}));
+
+vi.mock('@/lib/server/storage/s3', () => ({
+  getS3Config: () => ({ bucket: 'test-bucket' }),
+  getS3Client: () => ({ send: mocks.send }),
+  getS3ProxyClient: () => ({ send: mocks.send }),
+}));
+
+import { deleteTtsSegmentPrefix } from '../../src/lib/server/tts/segments-blobstore';
+
+describe('TTS segment blob cleanup', () => {
+  beforeEach(() => {
+    mocks.send.mockReset();
+  });
+
+  test('counts successful quiet deletes by requested object count', async () => {
+    mocks.send
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'prefix/a.mp3' }, { Key: 'prefix/b.mp3' }],
+        IsTruncated: false,
+      })
+      .mockResolvedValueOnce({});
+
+    await expect(deleteTtsSegmentPrefix('prefix/')).resolves.toBe(2);
+  });
+
+  test('fails cleanup when storage reports per-object deletion errors', async () => {
+    mocks.send
+      .mockResolvedValueOnce({
+        Contents: [{ Key: 'prefix/a.mp3' }],
+        IsTruncated: false,
+      })
+      .mockResolvedValueOnce({
+        Errors: [{ Key: 'prefix/a.mp3', Code: 'AccessDenied' }],
+      });
+
+    await expect(deleteTtsSegmentPrefix('prefix/')).rejects.toThrow(
+      'Failed deleting 1 TTS segment audio objects',
+    );
+  });
+});

--- a/tests/unit/tts-segments.vitest.spec.ts
+++ b/tests/unit/tts-segments.vitest.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  buildTtsSegmentDocumentPrefix,
   buildProportionalAlignment,
   buildTtsSegmentEntryId,
   buildTtsSegmentId,
@@ -12,6 +13,15 @@ import {
 } from '../../src/lib/server/tts/segments';
 
 describe('tts segment helpers', () => {
+  test('builds a user/document-scoped audio prefix across every version and variant', () => {
+    expect(buildTtsSegmentDocumentPrefix({
+      storagePrefix: 'openreader',
+      namespace: 'test namespace',
+      userId: 'user/name',
+      documentId: 'doc-id',
+    })).toBe('openreader/tts_segments_v2/ns/test namespace/users/user%2Fname/docs/doc-id/');
+  });
+
   test('builds stable settings hash', () => {
     const a = buildTtsSegmentSettingsHash({
       providerRef: 'openai',

--- a/tests/unit/user-data-cleanup.vitest.spec.ts
+++ b/tests/unit/user-data-cleanup.vitest.spec.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  selectResults: [] as unknown[][],
+  deleteWhere: vi.fn(async () => undefined),
+  deleteDocumentBlob: vi.fn(async () => undefined),
+  deleteDocumentPrefix: vi.fn(async () => 0),
+  deleteDocumentPreviewArtifacts: vi.fn(async () => 0),
+  deleteDocumentPreviewRows: vi.fn(async () => undefined),
+  deleteAudiobookPrefix: vi.fn(async () => 0),
+  deleteTtsSegmentPrefix: vi.fn(async () => 0),
+}));
+
+function resultBuilder(result: unknown[]) {
+  return {
+    limit: async () => result,
+    then: (resolve: (value: unknown[]) => unknown, reject: (error: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject),
+  };
+}
+
+vi.mock('@/db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => resultBuilder(mocks.selectResults.shift() ?? [])),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: mocks.deleteWhere,
+    })),
+  },
+}));
+
+vi.mock('@/lib/server/storage/s3', () => ({
+  isS3Configured: () => true,
+  getS3Config: () => ({ prefix: 'openreader-test' }),
+}));
+
+vi.mock('@/lib/server/documents/blobstore', () => ({
+  deleteDocumentBlob: mocks.deleteDocumentBlob,
+  deleteDocumentPrefix: mocks.deleteDocumentPrefix,
+  tempDocumentUploadPrefix: () => 'temp/user/',
+}));
+
+vi.mock('@/lib/server/documents/previews-blobstore', () => ({
+  deleteDocumentPreviewArtifacts: mocks.deleteDocumentPreviewArtifacts,
+}));
+
+vi.mock('@/lib/server/documents/previews', () => ({
+  deleteDocumentPreviewRows: mocks.deleteDocumentPreviewRows,
+}));
+
+vi.mock('@/lib/server/audiobooks/blobstore', () => ({
+  audiobookPrefix: () => 'audiobooks/user/',
+  deleteAudiobookPrefix: mocks.deleteAudiobookPrefix,
+}));
+
+vi.mock('@/lib/server/tts/segments-blobstore', () => ({
+  deleteTtsSegmentPrefix: mocks.deleteTtsSegmentPrefix,
+}));
+
+vi.mock('@/lib/server/logger', () => ({
+  hashForLog: () => 'hash',
+  serverLogger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/server/errors/logging', () => ({
+  logDegraded: vi.fn(),
+}));
+
+import { deleteUserStorageData } from '../../src/lib/server/user/data-cleanup';
+
+describe('user data cleanup', () => {
+  beforeEach(() => {
+    mocks.selectResults = [];
+    for (const mock of Object.values(mocks)) {
+      if (typeof mock === 'function' && 'mockReset' in mock) {
+        mock.mockReset();
+      }
+    }
+    mocks.deleteWhere.mockResolvedValue(undefined);
+    mocks.deleteDocumentBlob.mockResolvedValue(undefined);
+    mocks.deleteDocumentPrefix.mockResolvedValue(0);
+    mocks.deleteDocumentPreviewArtifacts.mockResolvedValue(0);
+    mocks.deleteDocumentPreviewRows.mockResolvedValue(undefined);
+    mocks.deleteAudiobookPrefix.mockResolvedValue(0);
+    mocks.deleteTtsSegmentPrefix.mockResolvedValue(0);
+  });
+
+  test('keeps shared document blobs and previews', async () => {
+    mocks.selectResults = [
+      [{ id: 'shared-doc' }],
+      [{ id: 'shared-doc' }],
+      [],
+    ];
+
+    await deleteUserStorageData('user-1', null);
+
+    expect(mocks.deleteDocumentBlob).not.toHaveBeenCalled();
+    expect(mocks.deleteDocumentPreviewArtifacts).not.toHaveBeenCalled();
+    expect(mocks.deleteDocumentPreviewRows).not.toHaveBeenCalled();
+    expect(mocks.deleteWhere).toHaveBeenCalledTimes(3);
+  });
+
+  test('blocks database cleanup when storage cleanup fails', async () => {
+    mocks.selectResults = [[], []];
+    mocks.deleteDocumentPrefix.mockRejectedValueOnce(new Error('storage unavailable'));
+
+    await expect(deleteUserStorageData('user-1', null)).rejects.toThrow(
+      'User storage cleanup failed',
+    );
+    expect(mocks.deleteWhere).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/user-preferences-normalize.vitest.spec.ts
+++ b/tests/unit/user-preferences-normalize.vitest.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  sanitizePreferencesPatch,
+  type PreferenceNormalizationContext,
+} from '../../src/lib/server/user/preferences-normalize';
+
+function makeContext(overrides: Partial<PreferenceNormalizationContext> = {}): PreferenceNormalizationContext {
+  return {
+    showAllProviderModels: true,
+    restrictUserApiKeys: true,
+    sharedProviders: [
+      { slug: 'shared-a', providerType: 'openai', defaultModel: 'gpt-4o-mini-tts', defaultInstructions: 'hi' },
+      { slug: 'shared-b', providerType: 'custom-openai', defaultModel: 'kokoro', defaultInstructions: null },
+    ],
+    ...overrides,
+  };
+}
+
+describe('sanitizePreferencesPatch — inherit-by-default provider model', () => {
+  test('preserves an empty providerRef as "inherit" rather than collapsing to a concrete provider', () => {
+    const { patch, migrated } = sanitizePreferencesPatch(
+      { providerRef: '', voiceSpeed: 1.5 },
+      makeContext(),
+      { fillMissingProvider: true },
+    );
+    expect(patch.providerRef).toBe('');
+    expect(patch.providerType).toBe('unknown');
+    expect(patch.ttsModel).toBe('');
+    expect(patch.voiceSpeed).toBe(1.5);
+    expect(migrated).toBe(false);
+  });
+
+  test('migrates a stale built-in (custom-openai) selection to inherit under restricted mode', () => {
+    const { patch, migrated } = sanitizePreferencesPatch(
+      { providerRef: 'custom-openai', providerType: 'custom-openai', ttsModel: 'kokoro' },
+      makeContext({ restrictUserApiKeys: true }),
+      { fillMissingProvider: true },
+    );
+    expect(patch.providerRef).toBe('');
+    expect(patch.providerType).toBe('unknown');
+    expect(patch.ttsModel).toBe('');
+    expect(migrated).toBe(true);
+  });
+
+  test('keeps an explicit built-in selection when API keys are NOT restricted', () => {
+    const { patch } = sanitizePreferencesPatch(
+      { providerRef: 'openai', providerType: 'openai', ttsModel: 'tts-1' },
+      makeContext({ restrictUserApiKeys: false }),
+      { fillMissingProvider: false },
+    );
+    expect(patch.providerRef).toBe('openai');
+    expect(patch.providerType).toBe('openai');
+    expect(patch.ttsModel).toBe('tts-1');
+  });
+
+  test('preserves an explicit shared-provider selection and resolves its type', () => {
+    const { patch } = sanitizePreferencesPatch(
+      { providerRef: 'shared-b', ttsModel: 'my-model' },
+      makeContext(),
+      { fillMissingProvider: false },
+    );
+    expect(patch.providerRef).toBe('shared-b');
+    expect(patch.providerType).toBe('custom-openai');
+    expect(patch.ttsModel).toBe('my-model');
+  });
+
+  test('locks the model to the shared provider default when showAllProviderModels is false', () => {
+    const { patch } = sanitizePreferencesPatch(
+      { providerRef: 'shared-a', ttsModel: 'something-else' },
+      makeContext({ showAllProviderModels: false }),
+      { fillMissingProvider: false },
+    );
+    expect(patch.providerRef).toBe('shared-a');
+    expect(patch.ttsModel).toBe('gpt-4o-mini-tts');
+  });
+
+  test('treats the legacy "default-openai" sentinel as inherit when it is not a real shared provider', () => {
+    const { patch, migrated } = sanitizePreferencesPatch(
+      { providerRef: 'default-openai' },
+      makeContext(),
+      { fillMissingProvider: true },
+    );
+    expect(patch.providerRef).toBe('');
+    expect(migrated).toBe(true);
+  });
+
+  test('does not force provider fields on a partial PUT patch that omits them', () => {
+    const { patch } = sanitizePreferencesPatch(
+      { voice: 'af_sarah' },
+      makeContext(),
+      { fillMissingProvider: false },
+    );
+    expect(patch.voice).toBe('af_sarah');
+    expect('providerRef' in patch).toBe(false);
+    expect('providerType' in patch).toBe(false);
+    expect('ttsModel' in patch).toBe(false);
+  });
+});

--- a/tests/unit/user-preferences-normalize.vitest.spec.ts
+++ b/tests/unit/user-preferences-normalize.vitest.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 import {
   sanitizePreferencesPatch,
+  sanitizeSavedVoices,
   type PreferenceNormalizationContext,
 } from '../../src/lib/server/user/preferences-normalize';
 
@@ -95,5 +96,13 @@ describe('sanitizePreferencesPatch — inherit-by-default provider model', () =>
     expect('providerRef' in patch).toBe(false);
     expect('providerType' in patch).toBe(false);
     expect('ttsModel' in patch).toBe(false);
+  });
+
+  test('rejects arrays where preference records are expected', () => {
+    expect(sanitizePreferencesPatch(['voice'], makeContext(), { fillMissingProvider: false })).toEqual({
+      patch: {},
+      migrated: false,
+    });
+    expect(sanitizeSavedVoices(['af_sarah'])).toEqual({});
   });
 });

--- a/tests/unit/user-preferences-sync.vitest.spec.ts
+++ b/tests/unit/user-preferences-sync.vitest.spec.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  cancelPendingPreferenceSync,
+  flushUserPreferencesSync,
+  scheduleUserPreferencesSync,
+} from '../../src/lib/client/api/user-state';
+
+type FetchMock = ReturnType<typeof vi.fn> & { calls: Array<{ url: string; init?: RequestInit }> };
+
+function installFetchMock(responder: () => Response): FetchMock {
+  const mock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    mock.calls.push({ url: String(input), init });
+    return responder();
+  }) as unknown as FetchMock;
+  mock.calls = [];
+  global.fetch = mock as unknown as typeof fetch;
+  return mock;
+}
+
+function okResponse(): Response {
+  return new Response(
+    JSON.stringify({ preferences: {}, clientUpdatedAtMs: Date.now(), applied: true }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+describe('flushUserPreferencesSync', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    cancelPendingPreferenceSync();
+  });
+
+  afterEach(() => {
+    cancelPendingPreferenceSync();
+    vi.useRealTimers();
+    global.fetch = originalFetch;
+  });
+
+  test('sends a pending debounced patch immediately instead of waiting for the timer', async () => {
+    const fetchMock = installFetchMock(okResponse);
+
+    scheduleUserPreferencesSync({ providerRef: 'shared-b', providerType: 'openai' }, 'user-1');
+
+    // Nothing should have fired yet — it's still debounced.
+    expect(fetchMock.calls).toHaveLength(0);
+
+    await flushUserPreferencesSync();
+
+    expect(fetchMock.calls).toHaveLength(1);
+    const { url, init } = fetchMock.calls[0];
+    expect(url).toContain('/api/user/state/preferences');
+    expect(init?.method).toBe('PUT');
+    const body = JSON.parse(String(init?.body));
+    expect(body.patch.providerRef).toBe('shared-b');
+    expect(body.patch.providerType).toBe('openai');
+
+    // The debounce timer must not also fire a duplicate request afterwards.
+    await vi.runAllTimersAsync();
+    expect(fetchMock.calls).toHaveLength(1);
+  });
+
+  test('is a no-op when there is no pending patch', async () => {
+    const fetchMock = installFetchMock(okResponse);
+    await flushUserPreferencesSync();
+    expect(fetchMock.calls).toHaveLength(0);
+  });
+
+  test('rejects when the server write fails so callers can surface the error', async () => {
+    installFetchMock(() => new Response(JSON.stringify({ error: 'boom' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    scheduleUserPreferencesSync({ providerRef: 'shared-b' }, 'user-1');
+
+    await expect(flushUserPreferencesSync()).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Add user data cleanup and export/delete flows with matching database cascade migrations.
- Normalize user preferences and TTS voice/language handling across server and client code.
- Update storage/blob cleanup paths and related API routes for documents, audiobooks, and TTS segments.
- Refresh docs and `.env.example` to reflect the new configuration and local setup requirements.
- Expand unit coverage for cleanup, export, language parsing, provider validation, and TTS segment handling.

## Testing
- Added and updated unit tests for data cleanup, preference normalization, TTS generation/segments, and provider validation.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for Kokoro language selection in TTS generation.
  * Enhanced user data exports to include TTS segment audio files and authentication metadata.
  * Settings modal now shows provider loading states and provides sync feedback.

* **Bug Fixes**
  * Improved storage cleanup error handling for object deletion operations.
  * Fixed cascading deletion of user-related data when accounts are removed.

* **Documentation**
  * Clarified that `API_KEY` is optional for provider configuration.
  * Updated provider seeding documentation to reflect `API_BASE` alone is sufficient when not requiring authentication.

* **Refactor**
  * Reorganized config provider mounting across application layouts for better state persistence.
  * Extracted preference validation logic into dedicated normalization module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->