### PR TITLE
Restore PDF Text Highlights After Viewport Resize (Fixes #119)

### DIFF
--- a/src/components/views/PDFViewer.tsx
+++ b/src/components/views/PDFViewer.tsx
@@ -39,6 +39,7 @@ interface PDFOnLinkClickArgs {
 export function PDFViewer({ zoomLevel, onDocumentReady, pdfState }: PDFViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isPageRendering, setIsPageRendering] = useState(false);
+  const [textLayerRenderRevision, setTextLayerRenderRevision] = useState(0);
   const hasSignaledReadyRef = useRef(false);
   const scaleRef = useRef<number>(1);
   const { containerWidth, containerHeight } = usePDFResize(containerRef);
@@ -106,6 +107,10 @@ export function PDFViewer({ zoomLevel, onDocumentReady, pdfState }: PDFViewerPro
     hasSignaledReadyRef.current = true;
     onDocumentReady?.();
   }, [onDocumentReady]);
+
+  const handleTextLayerRenderSuccess = useCallback(() => {
+    setTextLayerRenderRevision((revision) => revision + 1);
+  }, []);
 
   useEffect(() => {
     hasSignaledReadyRef.current = false;
@@ -228,6 +233,7 @@ export function PDFViewer({ zoomLevel, onDocumentReady, pdfState }: PDFViewerPro
     parsedDocument,
     resolvedLanguage,
     layoutKey,
+    textLayerRenderRevision,
     isPageRendering,
     clearSentenceHighlightTimeouts,
     scheduleSentenceTimeout
@@ -309,6 +315,7 @@ export function PDFViewer({ zoomLevel, onDocumentReady, pdfState }: PDFViewerPro
     clearWordHighlights,
     highlightWordIndex,
     layoutKey,
+    textLayerRenderRevision,
     clearWordHighlightTimeouts,
     scheduleWordTimeout,
     isPageRendering
@@ -546,6 +553,7 @@ export function PDFViewer({ zoomLevel, onDocumentReady, pdfState }: PDFViewerPro
                       setIsPageRendering(false);
                       markViewerReady();
                     }}
+                    onRenderTextLayerSuccess={handleTextLayerRenderSuccess}
                     onLoadSuccess={(page) => {
                       setPageWidth(page.originalWidth);
                       setPageHeight(page.originalHeight);
@@ -572,6 +580,7 @@ export function PDFViewer({ zoomLevel, onDocumentReady, pdfState }: PDFViewerPro
                       setIsPageRendering(false);
                       markViewerReady();
                     }}
+                    onRenderTextLayerSuccess={handleTextLayerRenderSuccess}
                     onLoadSuccess={(page) => {
                       setPageWidth(page.originalWidth);
                       setPageHeight(page.originalHeight);
@@ -594,6 +603,7 @@ export function PDFViewer({ zoomLevel, onDocumentReady, pdfState }: PDFViewerPro
                       setIsPageRendering(false);
                       markViewerReady();
                     }}
+                    onRenderTextLayerSuccess={handleTextLayerRenderSuccess}
                     onLoadSuccess={(page) => {
                       setPageWidth(page.originalWidth);
                       setPageHeight(page.originalHeight);

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -65,6 +65,23 @@ test.describe('PDF view modes and Navigator', () => {
     await setupTest(page, testInfo);
   });
 
+  test('restores the active PDF text highlight after narrowing the viewport', async ({ page }) => {
+    test.setTimeout(120_000);
+    await playTTSAndWaitForASecond(page, 'sample.pdf');
+
+    const textLayer = page.locator('.react-pdf__Page__textContent');
+    const textHighlight = page.locator('.pdf-text-highlight-overlay');
+    await expect(textLayer).toHaveCount(1);
+    await expect(textLayer.locator('span')).not.toHaveCount(0);
+    await expect(textHighlight).not.toHaveCount(0);
+
+    await triggerViewportResize(page, 615, 796);
+
+    await expect(textLayer).toHaveCount(1);
+    await expect(textLayer.locator('span')).not.toHaveCount(0);
+    await expect(textHighlight).not.toHaveCount(0);
+  });
+
   test('switches Single/Dual/Scroll modes and uses Navigator to change page', async ({ page }) => {
     test.setTimeout(120_000);
     // Open PDF viewer


### PR DESCRIPTION
# PR Summary: Restore PDF Text Highlights After Viewport Resize (Fixes #119)

This Pull Request resolves issue #119, where the active PDF text highlighting overlays (sentence-level and word-level) would disappear and fail to restore when resizing the browser window or narrowing the viewport.

---

## 🔍 The Problem

When a user resizes their viewport, the layout dimensions of the PDF viewer change. This updates the `layoutKey` and prompts `react-pdf`'s `<Page>` components to re-render. 

1. During this re-render, the browser's DOM elements for the text layer (`.react-pdf__Page__textContent`) are destroyed and recreated asynchronously.
2. In the previous implementation, the `useEffect` hooks responsible for rendering sentence and word highlights relied on `isPageRendering` and `layoutKey` to trigger.
3. Because the text layer renders asynchronously *after* page layout rendering is completed, a race condition occurred: the highlight hooks would execute before the new text layer spans were inserted into the DOM, or they would draw highlights on old spans that were subsequently destroyed. Since there was no mechanism to listen to the text layer completion, the highlights were never restored.

---

## 🛠️ The Solution

This PR implements a robust synchronization mechanism using `react-pdf`'s native text layer rendering callbacks:

### 1. `src/components/views/PDFViewer.tsx`
- **Revision State (`textLayerRenderRevision`):** Added a state counter initialized to `0` to track when a text layer is successfully painted in the DOM.
- **Render Success Callback:** Created a memoized callback `handleTextLayerRenderSuccess` that increments the revision counter:
  ```typescript
  const handleTextLayerRenderSuccess = useCallback(() => {
    setTextLayerRenderRevision((revision) => revision + 1);
  }, []);
  ```
- **Page Component Integration:** Passed `onRenderTextLayerSuccess={handleTextLayerRenderSuccess}` to all `<Page>` instances rendered by the viewer (supporting Single, Dual, and Scroll views).
- **Highlight Hooks Dependency Sync:** Appended `textLayerRenderRevision` to the dependency arrays of both the sentence-level highlight `useEffect` and word-level highlight `useEffect`.
  - Now, whenever a text layer successfully finishes rendering (e.g., following a scale or layout resize), the highlight hooks are guaranteed to trigger again and repaint the overlays on top of the newly mounted DOM text spans.

### 2. `tests/navigation.spec.ts`
- **End-to-End Test Integration:** Added a new integration test: `'restores the active PDF text highlight after narrowing the viewport'`.
- **Test Workflow:**
  1. Opens a PDF document and starts Text-to-Speech playback to generate active highlights.
  2. Asserts that the text layer and highlight overlays exist in the DOM.
  3. Triggers a viewport resize using `page.setViewportSize({ width: 615, height: 796 })`.
  4. Verifies that after resizing, the text layer spans and highlight overlays are correctly restored and present.

---

## 🧪 Verification & Results

The Playwright integration tests were run and validated successfully across all major browser engines (Chromium, Firefox, and Webkit).

### Automated Tests Run
```bash
pnpm playwright test tests/navigation.spec.ts -g "restores the active PDF text highlight after narrowing the viewport"
```

### Results
```text
Running 3 tests using 3 workers

[1/3] [firefox] › tests/navigation.spec.ts:68:7 › PDF view modes and Navigator › restores the active PDF text highlight after narrowing the viewport
[2/3] [chromium] › tests/navigation.spec.ts:68:7 › PDF view modes and Navigator › restores the active PDF text highlight after narrowing the viewport
[3/3] [webkit] › tests/navigation.spec.ts:68:7 › PDF view modes and Navigator › restores the active PDF text highlight after narrowing the viewport
  3 passed (52.4s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text highlighting in the PDF viewer to ensure highlights render correctly after the page finishes loading. Highlights now persist properly when resizing the viewport and remain visible when using text-to-speech functionality.

* **Tests**
  * Added tests to validate text highlighting behavior in PDF view modes, including scenarios with viewport resizing and active text-to-speech playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->