### PR TITLE
fix(storage): use same-origin fallback for blob URLs when S3 endpoint is loopback

### DIFF
--- a/src/app/api/documents/blob/get/presign/route.ts
+++ b/src/app/api/documents/blob/get/presign/route.ts
@@ -5,7 +5,7 @@ import { documents } from '@openreader/database/schema';
 import { requireAuthContext } from '@/lib/server/auth/auth';
 import { isValidDocumentId, presignGet } from '@/lib/server/documents/blobstore';
 import { getOpenReaderTestNamespace } from '@/lib/server/testing/test-namespace';
-import { isS3Configured } from '@/lib/server/storage/s3';
+import { isLoopbackS3Endpoint, isS3Configured } from '@/lib/server/storage/s3';
 import { errorToLog, serverLogger } from '@/lib/server/logger';
 import { errorResponse } from '@/lib/server/errors/next-response';
 
@@ -50,7 +50,11 @@ export async function GET(req: NextRequest) {
     }
 
     const fallbackUrl = `/api/documents/blob/get/fallback?id=${encodeURIComponent(doc.id)}`;
-    const directUrl = await presignGet(doc.id, testNamespace).catch(() => null);
+    // Loopback S3 endpoints yield presigned URLs unreachable from a remote
+    // browser; serve through the same-origin proxy fallback instead.
+    const directUrl = isLoopbackS3Endpoint()
+      ? null
+      : await presignGet(doc.id, testNamespace).catch(() => null);
     if (!directUrl) {
       serverLogger.warn({
         event: 'documents.blob.get.presign.unavailable',

--- a/src/app/api/documents/blob/preview/presign/route.ts
+++ b/src/app/api/documents/blob/preview/presign/route.ts
@@ -4,6 +4,7 @@ import { ensureDocumentPreview } from '@/lib/server/documents/previews';
 import { validatePreviewRequest } from '../utils';
 import { errorToLog, serverLogger } from '@/lib/server/logger';
 import { errorResponse } from '@/lib/server/errors/next-response';
+import { isLoopbackS3Endpoint } from '@/lib/server/storage/s3';
 
 export const dynamic = 'force-dynamic';
 
@@ -37,7 +38,11 @@ export async function GET(req: NextRequest) {
       );
     }
 
-    const directUrl = await presignDocumentPreviewGet(doc.id, testNamespace).catch(() => null);
+    // Loopback S3 endpoints yield presigned URLs unreachable from a remote
+    // browser; serve through the same-origin proxy fallback instead.
+    const directUrl = isLoopbackS3Endpoint()
+      ? null
+      : await presignDocumentPreviewGet(doc.id, testNamespace).catch(() => null);
     if (!directUrl) {
       serverLogger.warn({
         event: 'documents.preview.presign.unavailable',

--- a/src/lib/server/storage/s3.ts
+++ b/src/lib/server/storage/s3.ts
@@ -44,6 +44,28 @@ function loopbackEndpoint(endpoint: string | undefined): string | undefined {
   }
 }
 
+/**
+ * Returns true when the configured S3 endpoint is a loopback/localhost address.
+ *
+ * Presigned direct-to-storage URLs are signed against S3_ENDPOINT and handed to
+ * the browser. When S3_ENDPOINT is a loopback address they only resolve if the
+ * browser runs on the same host as the server. The recommended embedded
+ * SeaweedFS deployment behind a reverse proxy sets `S3_ENDPOINT=http://127.0.0.1:8333`
+ * (the internal proxy client also rewrites to loopback), so those presigned URLs
+ * are unreachable from a remote browser. In that case callers should serve blobs
+ * through the same-origin `/api/.../fallback` proxy routes instead of presigning.
+ */
+export function isLoopbackS3Endpoint(): boolean {
+  const config = loadS3ConfigFromEnv();
+  if (!config?.endpoint) return false;
+  try {
+    const host = new URL(config.endpoint).hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    return host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '0.0.0.0';
+  } catch {
+    return false;
+  }
+}
+
 function loadS3ConfigFromEnv(): S3Config | null {
   const bucket = process.env.S3_BUCKET?.trim();
   const region = process.env.S3_REGION?.trim();

--- a/src/lib/server/tts/segment-audio-urls.ts
+++ b/src/lib/server/tts/segment-audio-urls.ts
@@ -1,4 +1,5 @@
 import { presignTtsSegmentAudioGet } from '@/lib/server/tts/segments-blobstore';
+import { isLoopbackS3Endpoint } from '@/lib/server/storage/s3';
 
 export type TTSSegmentAudioUrls = {
   audioPresignUrl: string | null;
@@ -30,10 +31,16 @@ export async function resolveSegmentAudioUrls(
     };
   }
 
+  // A loopback S3 endpoint (the embedded-SeaweedFS-behind-a-reverse-proxy default,
+  // S3_ENDPOINT=http://127.0.0.1:8333) produces presigned URLs that a remote
+  // browser cannot reach. Serve audio through the same-origin fallback proxy in
+  // that case instead of handing out an unreachable direct URL.
   const presignResolver = options.presignResolver ?? presignTtsSegmentAudioGet;
-  const directUrl = await presignResolver(options.audioKey, {
-    expiresInSeconds: options.expiresInSeconds,
-  }).catch(() => null);
+  const directUrl = isLoopbackS3Endpoint()
+    ? null
+    : await presignResolver(options.audioKey, {
+        expiresInSeconds: options.expiresInSeconds,
+      }).catch(() => null);
 
   return {
     audioPresignUrl: directUrl ?? fallbackUrl,


### PR DESCRIPTION
## Problem

With embedded SeaweedFS behind an HTTPS reverse proxy, the working config sets `S3_ENDPOINT=http://127.0.0.1:8333` (the internal proxy client rewrites to loopback anyway via `getS3ProxyClient`, and `:8333` can't be served on the HTTPS origin without tripping mixed-content). But presigned URLs are signed against `S3_ENDPOINT` and handed to the **browser** — for TTS segment audio, document downloads, and previews. The browser then receives `http://127.0.0.1:8333/...` URLs that resolve to *its own* localhost and fail (`net::ERR_*` / status 0).

The client only fails over to the same-origin proxy route for the *actively playing* item, so prefetched TTS segments arrive already-failed and playback silently skips them.

## Fix

Add `isLoopbackS3Endpoint()`. When the endpoint host is loopback/localhost, the three browser-facing GET paths (`tts/segments/audio`, `documents/blob/get`, `documents/blob/preview`) skip presigning and return the existing same-origin `/api/.../fallback` proxy URL. Each route already had a `directUrl == null` fallback branch, so this only changes *which* URL the browser receives. No behavior change when `S3_ENDPOINT` is a publicly reachable host.

## Testing

Deployed behind a reverse proxy with `S3_ENDPOINT=http://127.0.0.1:8333`. Before: audio GETs to `127.0.0.1:8333` returned status 0 in the browser; after: same-origin `/api/tts/segments/audio/fallback` returns 200/206 and audio loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved downloads, previews, and audio segment playback when storage is configured on a local or loopback endpoint.
  * These requests now reliably use the existing same-origin fallback path instead of generating unusable direct links.
  * This helps remote browsers access content correctly in embedded or reverse-proxy setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->