### PR TITLE
fix(tts/html): segment HTML & Markdown per block instead of one merged string

### DIFF
--- a/src/app/(app)/html/[id]/useHtmlDocument.ts
+++ b/src/app/(app)/html/[id]/useHtmlDocument.ts
@@ -6,6 +6,7 @@ import { useTTS } from '@/contexts/TTSContext';
 import { useConfig } from '@/contexts/ConfigContext';
 import { ensureCachedDocument } from '@/lib/client/cache/documents';
 import { parseHtmlBlocks, type HtmlBlock } from '@/lib/client/html/blocks';
+import type { CanonicalTtsSourceUnit } from '@/lib/shared/tts-segment-plan';
 import { createHtmlAudiobookSourceAdapter } from '@/lib/client/audiobooks/adapters/html';
 import { regenerateAudiobookChapter, runAudiobookGeneration } from '@/lib/client/audiobooks/pipeline';
 import type {
@@ -51,16 +52,33 @@ function isTxtName(name: string | undefined | null): boolean {
 }
 
 /**
- * Concatenate every block's plain text into one TTS source. We treat the
- * entire HTML/TXT/MD document as a single "page" with a flat sequence of
- * segments (sentence indices), so playback advances naturally through the
- * doc without any per-block locator bookkeeping.
+ * Concatenate every block's plain text into one TTS source string. Kept for the
+ * playback-ready / change-detection key and blank-doc checks.
  */
 function buildFullDocumentText(blocks: HtmlBlock[]): string {
   return blocks
     .map((b) => b.plainText)
     .filter((t) => t && t.trim())
     .join('\n\n');
+}
+
+/**
+ * Feed one TTS source unit per top-level block (heading, paragraph, list, ...)
+ * so segment planning respects block boundaries: each block becomes its own
+ * segment(s) with an `{ readerType: 'html', location: anchorId }` locator for
+ * scoped highlighting. Previously the whole document was fed as a single
+ * concatenated string, which collapsed the `\n\n` block separators during
+ * audio-text normalization and let the block packer merge unrelated paragraphs
+ * (and headings) into one run-on segment — the cause of "skipped" paragraphs.
+ */
+function buildBlockSourceUnits(blocks: HtmlBlock[]): CanonicalTtsSourceUnit[] {
+  return blocks
+    .filter((b) => b.plainText && b.plainText.trim())
+    .map((b) => ({
+      sourceKey: b.anchorId,
+      text: b.plainText,
+      locator: { readerType: 'html' as const, location: b.anchorId },
+    }));
 }
 
 export function useHtmlDocument(): HtmlDocumentState {
@@ -81,6 +99,7 @@ export function useHtmlDocument(): HtmlDocumentState {
   );
 
   const currDocText = useMemo(() => buildFullDocumentText(blocks), [blocks]);
+  const blockSourceUnits = useMemo(() => buildBlockSourceUnits(blocks), [blocks]);
 
   // HTML reader is not an EPUB reader.
   useEffect(() => {
@@ -110,9 +129,10 @@ export function useHtmlDocument(): HtmlDocumentState {
     }
     setIsPlaybackReady(false);
     lastFedDocRef.current = key;
-    setTTSText(currDocText);
+    // Feed one source unit per block so segment planning keeps block boundaries.
+    setTTSText(currDocText, blockSourceUnits.length > 0 ? { sourceUnits: blockSourceUnits } : undefined);
     setIsPlaybackReady(true);
-  }, [currDocName, currDocText, currDocData, setTTSText]);
+  }, [currDocName, currDocText, currDocData, blockSourceUnits, blocks.length, setTTSText]);
 
   const clearCurrDoc = useCallback(() => {
     setCurrDocData(undefined);

--- a/src/contexts/TTSContext.tsx
+++ b/src/contexts/TTSContext.tsx
@@ -1345,7 +1345,11 @@ export function TTSProvider({ children }: { children: ReactNode }): ReactElement
         readerType: activeReaderType,
         maxBlockLength: ttsSegmentMaxBlockLength,
         keyPrefix: buildSegmentKeyPrefix(documentId, activeReaderType),
-        enforceSourceBoundaries: activeReaderType === 'pdf' && currentUnits !== null && currentUnits.length > 0,
+        // PDF and HTML/MD both feed one source unit per block; enforce boundaries
+        // so blocks (headings, paragraphs) never merge into one run-on segment.
+        enforceSourceBoundaries:
+          (activeReaderType === 'pdf' || activeReaderType === 'html')
+          && currentUnits !== null && currentUnits.length > 0,
         language: resolvedLanguage,
       });
       currentSegments = plan.segments.filter((segment) => currentSourceKeySet.has(segment.ownerSourceKey));


### PR DESCRIPTION
## Problem

The HTML/Markdown reader (`useHtmlDocument`) feeds the whole document to TTS as one concatenated string (blocks joined by `\n\n`). `normalizeSourceText` → `preprocessSentenceForAudio` collapses all whitespace before `splitTextToTtsBlocks` runs, so the `\n{2,}` paragraph boundaries are gone and the entire document is treated as a single paragraph. The block packer then merges the title and unrelated paragraphs into ~450-char run-on segments.

Because segments are keyed by their text (`buildSegmentKey`), an individual paragraph has no addressable segment: per-block highlighting breaks, and playback reads a heading + several paragraphs as one run-on, then jumps to the next chunk (perceived as skipping paragraphs).

## Fix

Feed one `CanonicalTtsSourceUnit` per parsed `HtmlBlock` (with an `{ readerType: 'html', location: anchorId }` locator) and enable `enforceSourceBoundaries` for the `html` reader — exactly what the PDF reader already does. Each heading/paragraph becomes its own segment(s) with correct boundaries.

## Testing

A 44-block markdown document: before, planning produced ~6 merged 340–450-char segments (title fused with the intro paragraph); after, 46 per-block segments (title = 49 chars, headings = 18 chars, paragraphs sized individually), each addressable for highlighting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text-to-speech handling for HTML documents by using block-aware source units, which helps playback and highlighting stay aligned with on-screen content.

* **Bug Fixes**
  * Tightened text-to-speech segment boundaries for HTML and PDF content, reducing cases where neighboring content could be merged incorrectly during playback planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->