### PR TITLE
fix(tts/audio): repair concatenated mp3 with under-reporting Xing header

### DIFF
--- a/src/lib/server/tts/audio-format.ts
+++ b/src/lib/server/tts/audio-format.ts
@@ -177,16 +177,56 @@ export async function transcodeToMp3(buffer: Buffer, signal?: AbortSignal): Prom
 }
 
 /**
+ * Detects an mp3 whose leading Xing/Info VBR header under-reports the stream
+ * size — the fingerprint of concatenated mp3 chunks. Some OpenAI-compatible TTS
+ * servers (e.g. DeepInfra's Kokoro) stream audio as several independent mp3
+ * segments glued together but keep only the *first* chunk's Xing header. The
+ * HTML5 <audio> element trusts that header for VBR duration, so it plays only the
+ * first chunk (~2s) and fires `ended` early — the rest of the segment is silently
+ * skipped. We compare the Xing-declared byte count to the real buffer length.
+ */
+function hasUnderreportingXingHeader(buffer: Buffer): boolean {
+  const searchEnd = Math.min(buffer.length, 4096);
+  let tagPos = -1;
+  for (const tag of ['Xing', 'Info']) {
+    const p = buffer.indexOf(tag, 0, 'latin1');
+    if (p >= 0 && p < searchEnd) { tagPos = p; break; }
+  }
+  if (tagPos < 0 || tagPos + 8 > buffer.length) return false;
+  const flags = buffer.readUInt32BE(tagPos + 4);
+  let cursor = tagPos + 8;
+  if (flags & 0x1) cursor += 4; // frames field present — skip it
+  if (!(flags & 0x2)) return false; // no byte-count field to validate against
+  if (cursor + 4 > buffer.length) return false;
+  const declaredBytes = buffer.readUInt32BE(cursor);
+  if (declaredBytes <= 0) return false;
+  // A well-formed Xing describes ~the whole file; a concatenated file's header
+  // describes only the first chunk, far below the real size.
+  return declaredBytes < buffer.length * 0.7;
+}
+
+/**
  * Ensure a TTS buffer is mp3. OpenAI-compatible servers vary in which audio
  * formats they emit (some default to or only support wav), so we sniff the bytes
  * and transcode anything that isn't already mp3. Real-mp3 responses pass through
- * untouched, so the common path adds zero cost.
+ * untouched, so the common path adds zero cost — except concatenated-chunk mp3
+ * with a broken Xing header, which is re-encoded so its duration is accurate and
+ * HTML5 playback doesn't truncate mid-segment.
  */
 export async function normalizeToMp3(buffer: Buffer, signal?: AbortSignal): Promise<Buffer> {
   if (buffer.length === 0) return buffer;
 
   const format = sniffAudioFormat(buffer);
-  if (format === 'mp3') return buffer;
+  if (format === 'mp3') {
+    if (!hasUnderreportingXingHeader(buffer)) return buffer;
+    const repaired = await transcodeToMp3(buffer, signal);
+    serverLogger.info({
+      event: 'tts.audio_format.repaired_mp3_xing',
+      sourceBytes: buffer.length,
+      outputBytes: repaired.length,
+    }, 'Repaired concatenated mp3 with under-reporting Xing header');
+    return repaired;
+  }
 
   const transcoded = await transcodeToMp3(buffer, signal);
   serverLogger.info({


### PR DESCRIPTION
## Problem

`normalizeToMp3` passes real-mp3 responses through untouched. But some OpenAI-compatible TTS servers (e.g. **DeepInfra's Kokoro**) stream long audio as several independent mp3 chunks concatenated together, keeping only the **first** chunk's Xing/VBR header. That header describes ~the first chunk (e.g. 87 frames ≈ 2.3 s) even though the file is much longer (e.g. 29 s). The HTML5 `<audio>` element reads the Xing header to compute VBR duration, fires `ended` after ~2 s, and the rest of a long segment is silently skipped — perceived as the reader "skipping sentences." (`ffmpeg -i` on such a file reports `invalid concatenated file detected`.)

## Fix

Detect an mp3 whose leading Xing/Info header declares a byte count far below the actual buffer size (the concatenation fingerprint) and re-encode it through the existing `transcodeToMp3` path, which writes a correct Xing header. Well-formed mp3 still passes through with zero added cost.

## Testing

DeepInfra Kokoro segment: the stored mp3 was 185 KB / 29 s, but its Xing header claimed 87 frames (~2.3 s); the browser played 2.1 s and advanced. After the fix the repaired mp3 reports the correct ~27 s duration and plays in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
